### PR TITLE
chore(*): Validate Cloud Firestore collection paths input.

### DIFF
--- a/firestore-stripe-invoices/extension.yaml
+++ b/firestore-stripe-invoices/extension.yaml
@@ -107,6 +107,8 @@ params:
     description: >-
       What is the path to the Cloud Firestore collection where you'll store your invoices?
     default: invoices
+    validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
+    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".
     required: true
 
   - param: STRIPE_API_KEY

--- a/firestore-stripe-subscriptions/extension.yaml
+++ b/firestore-stripe-subscriptions/extension.yaml
@@ -142,6 +142,8 @@ params:
     description: >-
       What is the path to the Cloud Firestore collection where the extension should store Stripe pricing plans?
     default: products
+    validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
+    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".
     required: true
 
   - param: CUSTOMERS_COLLECTION
@@ -149,6 +151,8 @@ params:
     description: >-
       What is the path to the Cloud Firestore collection where the extension should store Stripe customer details?
     default: customers
+    validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
+    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".
     required: true
 
   - param: STRIPE_API_KEY


### PR DESCRIPTION
Fixes #28 

- Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".