### PR TITLE
fix(firestore-stripe-subscriptions): More secure security rules example.

### DIFF
--- a/firestore-stripe-subscriptions/CHANGELOG.md
+++ b/firestore-stripe-subscriptions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [change] - Only log the `stripeRole` custom claim, not the whole claim object.
 
-[fix] - Fix security rules example in `POSTINSTALL.md` (#47)
+[fix] - Fix security rules example in `POSTINSTALL.md`. (#47)
 
 [fix] - Supply email address to Stripe customer creation also for existing Firebase users. (#42)
 

--- a/firestore-stripe-subscriptions/CHANGELOG.md
+++ b/firestore-stripe-subscriptions/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Version 0.1.5 - 2020-08-20
 
-[changed] - Only log the `stripeRole` custom claim, not the whole claim object.
+[change] - Only log the `stripeRole` custom claim, not the whole claim object.
+
+[fix] - Fix security rules example in `POSTINSTALL.md` (#47)
 
 [fix] - Supply email address to Stripe customer creation also for existing Firebase users. (#42)
 

--- a/firestore-stripe-subscriptions/POSTINSTALL.md
+++ b/firestore-stripe-subscriptions/POSTINSTALL.md
@@ -16,23 +16,21 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /${param:CUSTOMERS_COLLECTION}/{uid} {
-      allow read, write: if request.auth.uid == uid;
+      allow read: if request.auth.uid == uid;
 
       match /checkout_sessions/{id} {
         allow read, write: if request.auth.uid == uid;
       }
       match /subscriptions/{id} {
-        allow read, write: if request.auth.uid == uid;
+        allow read: if request.auth.uid == uid;
       }
     }
 
     match /${param:PRODUCTS_COLLECTION}/{id} {
       allow read: if true;
-      allow write: if false;
 
       match /prices/{id} {
         allow read: if true;
-        allow write: if false;
       }
     }
   }


### PR DESCRIPTION
Fixes #47 

[fix] - Fix security rules example in `POSTINSTALL.md`. (#47)