### PR TITLE
chore(*): add new cloud functions locations

### DIFF
--- a/firestore-stripe-invoices/extension.yaml
+++ b/firestore-stripe-invoices/extension.yaml
@@ -88,16 +88,38 @@ params:
         value: us-east1
       - label: Northern Virginia (us-east4)
         value: us-east4
+      - label: Los Angeles (us-west2)
+        value: us-west2
+      - label: Salt Lake City (us-west3)
+        value: us-west3
+      - label: Las Vegas (us-west4)
+        value: us-west4
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)
         value: europe-west2
       - label: Frankfurt (europe-west3)
         value: europe-west3
+      - label: Zurich (europe-west6)
+        value: europe-west6
       - label: Hong Kong (asia-east2)
         value: asia-east2
       - label: Tokyo (asia-northeast1)
         value: asia-northeast1
+      - label: Osaka (asia-northeast2)
+        value: asia-northeast2
+      - label: Seoul (asia-northeast3)
+        value: asia-northeast3
+      - label: Mumbai (asia-south1)
+        value: asia-south1
+      - label: Jakarta (asia-southeast2)
+        value: asia-southeast2
+      - label: Montreal (northamerica-northeast1)
+        value: northamerica-northeast1
+      - label: Sao Paulo (southamerica-east1)
+        value: southamerica-east1
+      - label: Sydney (australia-southeast1)
+        value: australia-southeast1
     default: us-central1
     required: true
     immutable: true

--- a/firestore-stripe-invoices/functions/package.json
+++ b/firestore-stripe-invoices/functions/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "firebase-admin": "^8.9.2",
-    "firebase-functions": "^3.3.0",
+    "firebase-functions": "^3.9.0",
     "stripe": "8.56.0"
   },
   "devDependencies": {

--- a/firestore-stripe-subscriptions/extension.yaml
+++ b/firestore-stripe-subscriptions/extension.yaml
@@ -123,16 +123,38 @@ params:
         value: us-east1
       - label: Northern Virginia (us-east4)
         value: us-east4
+      - label: Los Angeles (us-west2)
+        value: us-west2
+      - label: Salt Lake City (us-west3)
+        value: us-west3
+      - label: Las Vegas (us-west4)
+        value: us-west4
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)
         value: europe-west2
       - label: Frankfurt (europe-west3)
         value: europe-west3
+      - label: Zurich (europe-west6)
+        value: europe-west6
       - label: Hong Kong (asia-east2)
         value: asia-east2
       - label: Tokyo (asia-northeast1)
         value: asia-northeast1
+      - label: Osaka (asia-northeast2)
+        value: asia-northeast2
+      - label: Seoul (asia-northeast3)
+        value: asia-northeast3
+      - label: Mumbai (asia-south1)
+        value: asia-south1
+      - label: Jakarta (asia-southeast2)
+        value: asia-southeast2
+      - label: Montreal (northamerica-northeast1)
+        value: northamerica-northeast1
+      - label: Sao Paulo (southamerica-east1)
+        value: southamerica-east1
+      - label: Sydney (australia-southeast1)
+        value: australia-southeast1
     default: us-central1
     required: true
     immutable: true

--- a/firestore-stripe-subscriptions/functions/package.json
+++ b/firestore-stripe-subscriptions/functions/package.json
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "firebase-admin": "^8.9.2",
-    "firebase-functions": "^3.3.0",
+    "firebase-functions": "^3.9.0",
     "stripe": "8.83.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Cloud Functions [v3.8.0](https://github.com/firebase/firebase-functions/releases/tag/v3.8.0) and [v3.9.0](https://github.com/firebase/firebase-functions/releases/tag/v3.9.0) combined have added support for a total of 11 new regions.
This PR should add support for these regions :)

Equivalent PR on the 1st party extensions: https://github.com/firebase/extensions/pull/388