### PR TITLE
customer_update flag

### DIFF
--- a/firestore-stripe-subscriptions/functions/src/index.ts
+++ b/firestore-stripe-subscriptions/functions/src/index.ts
@@ -109,6 +109,7 @@ exports.createCheckoutSession = functions.firestore
       collect_shipping_address = false,
       locale = 'auto',
       promotion_code,
+      customer_update,
       client_reference_id,
     } = snap.data();
     try {
@@ -138,6 +139,7 @@ exports.createCheckoutSession = functions.firestore
         shipping_address_collection: { allowed_countries: shippingCountries },
         payment_method_types,
         customer,
+        customer_update,
         line_items: line_items
           ? line_items
           : [


### PR DESCRIPTION
Add the possibility to use customer_update for shipping addresses.

https://stripe.com/docs/tax/checkout#use-addresses-collected-during-checkout-for-taxes