### PR TITLE
refactor(*): add Warsaw Cloud Function Location

### DIFF
--- a/firestore-stripe-invoices/extension.yaml
+++ b/firestore-stripe-invoices/extension.yaml
@@ -94,6 +94,8 @@ params:
         value: us-west3
       - label: Las Vegas (us-west4)
         value: us-west4
+      - label: Warsaw (europe-central2)
+        value: europe-central2
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)

--- a/firestore-stripe-invoices/functions/package.json
+++ b/firestore-stripe-invoices/functions/package.json
@@ -11,8 +11,8 @@
   "author": "Stripe (https://stripe.com/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase-admin": "^8.9.2",
-    "firebase-functions": "^3.9.0",
+    "firebase-admin": "^9.9.0",
+    "firebase-functions": "^3.14.1",
     "stripe": "8.56.0"
   },
   "devDependencies": {

--- a/firestore-stripe-subscriptions/extension.yaml
+++ b/firestore-stripe-subscriptions/extension.yaml
@@ -129,6 +129,8 @@ params:
         value: us-west3
       - label: Las Vegas (us-west4)
         value: us-west4
+      - label: Warsaw (europe-central2)
+        value: europe-central2
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: London (europe-west2)

--- a/firestore-stripe-subscriptions/functions/package.json
+++ b/firestore-stripe-subscriptions/functions/package.json
@@ -11,8 +11,8 @@
   "author": "Stripe (https://stripe.com/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase-admin": "^8.9.2",
-    "firebase-functions": "^3.9.0",
+    "firebase-admin": "^9.9.0",
+    "firebase-functions": "^3.14.1",
     "stripe": "^8.135.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`firebase-functions` 3.14.1 introduces a new Cloud Function location: `Warsaw (europe-central2)`

This PR should:
- update `firebase-admin` to 9.9.0
- update `firebase-functions` to 3.14.1
- add the new location to the list of locations that developers can choose from when configuring the extensions.