### PR TITLE
ci: add validation job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,16 @@
+name: Validate
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: NPM Install & Build
+        run: npm i
+      - name: Prettier Lint Check
+        run: npm run lint


### PR DESCRIPTION
Adds start of CI to validate TS builds and formatting - via GitHub Actions.