### PR TITLE
feat: Added Product, Price and getProduct APIs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: NPM Install
         run: npm i
-      - name: NPM Build
-        run: npm run build
       - name: Unit Test
         run: lerna run --scope firestore-stripe-payments-js test
       - name: API Report

--- a/firestore-stripe-web-sdk/.gitignore
+++ b/firestore-stripe-web-sdk/.gitignore
@@ -1,3 +1,4 @@
+firestore-debug.log
 lib
 node_modules
 temp

--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -16,26 +16,16 @@ export function getStripePayments(app: FirebaseApp, options: StripePaymentsOptio
 export interface Price {
     // (undocumented)
     readonly [propName: string]: any;
-    // (undocumented)
     readonly active: boolean;
-    // (undocumented)
     readonly currency: string;
-    // (undocumented)
     readonly description: string | null;
-    // (undocumented)
     readonly id: string;
-    // (undocumented)
     readonly interval: "day" | "month" | "week" | "year" | null;
-    // (undocumented)
     readonly intervalCount: number | null;
-    // (undocumented)
     readonly productId: string;
-    // (undocumented)
     readonly trialPeriodDays: number | null;
-    // (undocumented)
     readonly type: "one_time" | "recurring";
-    // (undocumented)
-    readonly unitAmount: number;
+    readonly unitAmount: number | null;
 }
 
 // @public

--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -7,14 +7,74 @@
 import { FirebaseApp } from '@firebase/app';
 
 // @public
+export function getProduct(payments: StripePayments, productId: string): Promise<Product>;
+
+// @public
 export function getStripePayments(app: FirebaseApp, options: StripePaymentsOptions): StripePayments;
 
 // @public
+export interface Price {
+    // (undocumented)
+    readonly [propName: string]: any;
+    // (undocumented)
+    readonly active: boolean;
+    // (undocumented)
+    readonly currency: string;
+    // (undocumented)
+    readonly description: string | null;
+    // (undocumented)
+    readonly id: string;
+    // (undocumented)
+    readonly interval: "day" | "month" | "week" | "year" | null;
+    // (undocumented)
+    readonly intervalCount: number | null;
+    // (undocumented)
+    readonly productId: string;
+    // (undocumented)
+    readonly trialPeriodDays: number | null;
+    // (undocumented)
+    readonly type: "one_time" | "recurring";
+    // (undocumented)
+    readonly unitAmount: number;
+}
+
+// @public
+export interface Product {
+    // (undocumented)
+    readonly [propName: string]: any;
+    readonly active: boolean;
+    readonly description: string | null;
+    readonly id: string;
+    readonly images: string[];
+    readonly metadata: {
+        [key: string]: string | number | null;
+    };
+    readonly name: string;
+    readonly prices: Price[];
+    readonly role: string | null;
+}
+
+// @public
 export class StripePayments {
-    constructor(app: FirebaseApp);
     // (undocumented)
     readonly app: FirebaseApp;
+    get customersCollection(): string;
+    get productsCollection(): string;
 }
+
+// @public
+export class StripePaymentsError extends Error {
+    constructor(code: StripePaymentsErrorCode, message: string, cause?: any);
+    // (undocumented)
+    readonly cause?: any;
+    // (undocumented)
+    readonly code: StripePaymentsErrorCode;
+    // (undocumented)
+    readonly message: string;
+}
+
+// @public
+export type StripePaymentsErrorCode = "not-found" | "permission-denied" | "internal";
 
 // @public
 export interface StripePaymentsOptions {

--- a/firestore-stripe-web-sdk/package.json
+++ b/firestore-stripe-web-sdk/package.json
@@ -20,9 +20,13 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.18.7",
     "@types/chai": "^4.2.21",
+    "@types/chai-as-promised": "^7.1.4",
     "@types/mocha": "^9.0.0",
+    "@types/sinon": "^10.0.2",
     "chai": "^4.3.4",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^9.1.1",
+    "sinon": "^11.1.2",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.2"
   },

--- a/firestore-stripe-web-sdk/package.json
+++ b/firestore-stripe-web-sdk/package.json
@@ -5,10 +5,11 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "scripts": {
-    "api-extractor:local": "npm run build && api-extractor run --local --verbose",
     "api-extractor": "api-extractor run --verbose",
+    "api-extractor:local": "npm run build && api-extractor run --local --verbose",
     "build": "tsc",
-    "test": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha -r ts-node/register test/**/*.spec.ts"
+    "test": "firebase emulators:exec --only firestore 'npm run test:unit'",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha -r ts-node/register test/**/*.spec.ts"
   },
   "keywords": [
     "firebase",
@@ -25,6 +26,7 @@
     "@types/sinon": "^10.0.2",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
+    "firebase-tools": "^9.18.0",
     "mocha": "^9.1.1",
     "sinon": "^11.1.2",
     "ts-node": "^10.2.1",

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -16,6 +16,10 @@
 
 export {
   StripePayments,
+  StripePaymentsError,
+  StripePaymentsErrorCode,
   StripePaymentsOptions,
   getStripePayments,
 } from "./init";
+
+export { Product, Price, getProduct } from "./product";

--- a/firestore-stripe-web-sdk/src/init.ts
+++ b/firestore-stripe-web-sdk/src/init.ts
@@ -28,7 +28,7 @@ export function getStripePayments(
   app: FirebaseApp,
   options: StripePaymentsOptions
 ): StripePayments {
-  return new StripePayments(app);
+  return StripePayments.create(app, options);
 }
 
 /**
@@ -39,11 +39,82 @@ export interface StripePaymentsOptions {
   productsCollection: string;
 }
 
+type Components = Record<string, unknown>;
+
 /**
  * Holds the configuration and other state information of the SDK. An instance of this class
  * must be passed to almost all the other APIs of this library. Do not directly call the
  * constructor. Use the {@link getStripePayments} function to obtain an instance.
  */
 export class StripePayments {
-  constructor(readonly app: FirebaseApp) {}
+  private readonly components: Components = {};
+
+  private constructor(
+    readonly app: FirebaseApp,
+    private readonly options: StripePaymentsOptions
+  ) {}
+
+  /**
+   * @internal
+   */
+  static create(
+    app: FirebaseApp,
+    options: StripePaymentsOptions
+  ): StripePayments {
+    return new StripePayments(app, options);
+  }
+
+  /**
+   * Name of the customers collection as configured in the extension.
+   */
+  get customersCollection(): string {
+    return this.options.customersCollection;
+  }
+
+  /**
+   * Name of the products collection as configured in the extension.
+   */
+  get productsCollection(): string {
+    return this.options.productsCollection;
+  }
+
+  /**
+   * @internal
+   */
+  getComponent<T>(key: string): T | null {
+    let dao = this.components[key];
+    if (dao) {
+      return dao as T;
+    }
+
+    return null;
+  }
+
+  /**
+   * @internal
+   */
+  setComponent<T>(key: string, dao: T) {
+    this.components[key] = dao;
+  }
+}
+
+/**
+ * Union of possible error codes.
+ */
+export type StripePaymentsErrorCode =
+  | "not-found"
+  | "permission-denied"
+  | "internal";
+
+/**
+ * An error thrown by this SDK.
+ */
+export class StripePaymentsError extends Error {
+  constructor(
+    readonly code: StripePaymentsErrorCode,
+    readonly message: string,
+    readonly cause?: any
+  ) {
+    super(message);
+  }
 }

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 Stripe, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from "@firebase/app";
+import { doc, getDoc, getFirestore } from "@firebase/firestore";
+import { StripePayments, StripePaymentsError } from "./init";
+import { checkNonEmptyString, checkStripePayments } from "./utils";
+
+/**
+ * Interface of a Stripe Product stored in the app database.
+ */
+export interface Product {
+  /**
+   * Unique Stripe product ID.
+   */
+  readonly id: string;
+
+  /**
+   * Whether the product is currently available for purchase.
+   */
+  readonly active: boolean;
+
+  /**
+   * The product's name, meant to be displayable to the customer. Whenever this product is sold
+   * via a subscription, name will show up on associated invoice line item descriptions.
+   */
+  readonly name: string;
+
+  /**
+   * The product's description, meant to be displayable to the customer. Use this field to
+   * optionally store a long form explanation of the product being sold for your own
+   * rendering purposes.
+   */
+  readonly description: string | null;
+
+  /**
+   * The Firebase role that will be assigned to the user if they are subscribed to this plan.
+   */
+  readonly role: string | null;
+
+  /**
+   * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+   */
+  readonly images: string[];
+
+  /**
+   * A list of Prices for this billing product. Only populated if explicitly requested
+   * during retrieval.
+   */
+  readonly prices: Price[];
+
+  /**
+   * A collection of additional product metadata.
+   */
+  readonly metadata: { [key: string]: string | number | null };
+
+  readonly [propName: string]: any;
+}
+
+/**
+ * Interface of a Stripe Price stored in the app database.
+ */
+export interface Price {
+  readonly id: string;
+  readonly productId: string;
+  readonly active: boolean;
+  readonly currency: string;
+  readonly unitAmount: number;
+  readonly description: string | null;
+  readonly type: "one_time" | "recurring";
+  readonly interval: "day" | "month" | "week" | "year" | null;
+  readonly intervalCount: number | null;
+  readonly trialPeriodDays: number | null;
+  readonly [propName: string]: any;
+}
+
+/**
+ * Retrieves a Stripe product from the database.
+ *
+ * @param payments - A valid {@link StripePayments} object.
+ * @param productId - ID of the product to retrieve.
+ * @returns Resolves with a Stripe Product object if found. Rejects if the specified product ID
+ *  does not exist.
+ */
+export async function getProduct(
+  payments: StripePayments,
+  productId: string
+): Promise<Product> {
+  checkStripePayments(
+    payments,
+    "payments must be a valid StripePayments instance."
+  );
+  checkNonEmptyString(productId, "productId must be a non-empty string.");
+
+  const dao: ProductDAO = getOrInitProductDAO(payments);
+  return await dao.getProduct(productId);
+}
+
+/**
+ * @internal
+ */
+export interface ProductDAO {
+  getProduct(productId: string, options?: {includePrices?: boolean}): Promise<Product>;
+}
+
+class FirestoreProductDAO implements ProductDAO {
+  constructor(
+    private readonly app: FirebaseApp,
+    private readonly productsCollection: string
+  ) {}
+
+  public async getProduct(productId: string): Promise<Product> {
+    const firestore = getFirestore(this.app);
+    const productRef = doc(firestore, this.productsCollection, productId);
+    try {
+      const productSnap = await getDoc(productRef);
+      if (productSnap.exists()) {
+        return {...productSnap.data() as Product, id: productId, prices: []};
+      }
+
+      throw new StripePaymentsError("not-found", "no such productId");
+    } catch (error) {
+      throw new StripePaymentsError(
+        "internal",
+        "error while querying Firestore",
+        error
+      );
+    }
+  }
+}
+
+const PRODUCT_DAO_KEY = "product-dao" as const;
+
+function getOrInitProductDAO(payments: StripePayments): ProductDAO {
+  let dao: ProductDAO | null = payments.getComponent<ProductDAO>(
+    PRODUCT_DAO_KEY
+  );
+  if (!dao) {
+    dao = new FirestoreProductDAO(payments.app, payments.productsCollection);
+    setProductDAO(payments, dao);
+  }
+
+  return dao;
+}
+
+/**
+ * @internal
+ */
+export function setProductDAO(payments: StripePayments, dao: ProductDAO): void {
+  payments.setComponent(PRODUCT_DAO_KEY, dao);
+}

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -136,7 +136,10 @@ class FirestoreProductDAO implements ProductDAO {
       return { ...(productSnap.data() as Product), id: productId, prices: [] };
     }
 
-    throw new StripePaymentsError("not-found", `No product found with the ID: ${productId}`);
+    throw new StripePaymentsError(
+      "not-found",
+      `No product found with the ID: ${productId}`
+    );
   }
 
   private async queryProduct(productId: string): Promise<DocumentSnapshot> {

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -76,19 +76,63 @@ export interface Product {
 }
 
 /**
- * Interface of a Stripe Price stored in the app database.
+ * Interface of a Stripe Price object stored in the app database.
  */
 export interface Price {
+  /**
+   * Unique Stripe price ID.
+   */
   readonly id: string;
+
+  /**
+   * ID of the Stripe product to which this price is related.
+   */
   readonly productId: string;
+
+  /**
+   * Whether the price can be used for new purchases.
+   */
   readonly active: boolean;
+
+  /**
+   * Three-letter ISO currency code.
+   */
   readonly currency: string;
-  readonly unitAmount: number;
+
+  /**
+   * The unit amount in cents to be charged, represented as a whole integer if possible.
+   */
+  readonly unitAmount: number | null;
+
+  /**
+   * A brief description of the price.
+   */
   readonly description: string | null;
+
+  /**
+   * One of `one_time` or `recurring` depending on whether the price is for a one-time purchase
+   * or a recurring (subscription) purchase.
+   */
   readonly type: "one_time" | "recurring";
+
+  /**
+   * The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
+   */
   readonly interval: "day" | "month" | "week" | "year" | null;
+
+  /**
+   * The number of intervals (specified in the {@link Price.interval} attribute) between
+   * subscription billings. For example, `interval=month` and `interval_count=3` bills every
+   * 3 months.
+   */
   readonly intervalCount: number | null;
+
+  /**
+   * Default number of trial days when subscribing a customer to this price using
+   * {@link https://stripe.com/docs/api#create_subscription-trial_from_plan | trial_from_plan}.
+   */
   readonly trialPeriodDays: number | null;
+
   readonly [propName: string]: any;
 }
 
@@ -109,19 +153,18 @@ export async function getProduct(
     "payments must be a valid StripePayments instance."
   );
   checkNonEmptyString(productId, "productId must be a non-empty string.");
-
   const dao: ProductDAO = getOrInitProductDAO(payments);
   return await dao.getProduct(productId);
 }
 
 /**
+ * Internal interface for all database interactions pertaining to Stripe products. Exported
+ * for testing.
+ *
  * @internal
  */
 export interface ProductDAO {
-  getProduct(
-    productId: string,
-    options?: { includePrices?: boolean }
-  ): Promise<Product>;
+  getProduct(productId: string): Promise<Product>;
 }
 
 class FirestoreProductDAO implements ProductDAO {
@@ -172,6 +215,9 @@ function getOrInitProductDAO(payments: StripePayments): ProductDAO {
 }
 
 /**
+ * Internal API registering a {@link ProductDAO} instance with {@link StripePayments}. Exported
+ * for testing.
+ *
  * @internal
  */
 export function setProductDAO(payments: StripePayments, dao: ProductDAO): void {

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -136,7 +136,7 @@ class FirestoreProductDAO implements ProductDAO {
       return { ...(productSnap.data() as Product), id: productId, prices: [] };
     }
 
-    throw new StripePaymentsError("not-found", "no such productId");
+    throw new StripePaymentsError("not-found", `No product found with the ID: ${productId}`);
   }
 
   private async queryProduct(productId: string): Promise<DocumentSnapshot> {
@@ -147,7 +147,7 @@ class FirestoreProductDAO implements ProductDAO {
     } catch (error) {
       throw new StripePaymentsError(
         "internal",
-        "error while querying Firestore",
+        "Unexpected error while querying Firestore",
         error
       );
     }

--- a/firestore-stripe-web-sdk/src/utils.ts
+++ b/firestore-stripe-web-sdk/src/utils.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Stripe, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { StripePayments } from "./init";
 
 export function checkStripePayments(

--- a/firestore-stripe-web-sdk/src/utils.ts
+++ b/firestore-stripe-web-sdk/src/utils.ts
@@ -1,0 +1,18 @@
+import { StripePayments } from "./init";
+
+export function checkStripePayments(
+  payments: StripePayments,
+  message?: string
+): void {
+  if (!(payments instanceof StripePayments)) {
+    throw new Error(
+      message ?? "payments must be an instance of StripePayments."
+    );
+  }
+}
+
+export function checkNonEmptyString(arg: string, message?: string): void {
+  if (typeof arg !== "string" || arg === "") {
+    throw new Error(message ?? "arg must be a non-empty string.");
+  }
+}

--- a/firestore-stripe-web-sdk/test/init.spec.ts
+++ b/firestore-stripe-web-sdk/test/init.spec.ts
@@ -16,7 +16,11 @@
 
 import { FirebaseApp } from "@firebase/app";
 import { expect } from "chai";
-import { getStripePayments, StripePayments, StripePaymentsError } from "../src/index";
+import {
+  getStripePayments,
+  StripePayments,
+  StripePaymentsError,
+} from "../src/index";
 
 const app: FirebaseApp = {
   name: "mock",
@@ -61,7 +65,7 @@ describe("StripePayments", () => {
 
     it("should return the requested component when available", () => {
       const component: any = {};
-      payments.setComponent("test-component", component)
+      payments.setComponent("test-component", component);
 
       expect(payments.getComponent("test-component")).to.equal(component);
     });
@@ -70,32 +74,32 @@ describe("StripePayments", () => {
   describe("setComponent()", () => {
     it("should overwrite the existing component", () => {
       const component: any = {};
-      const otherComponent: any = {other: true};
+      const otherComponent: any = { other: true };
 
-      payments.setComponent("test-component", component)
+      payments.setComponent("test-component", component);
       expect(payments.getComponent("test-component")).to.equal(component);
 
-      payments.setComponent("test-component", otherComponent)
+      payments.setComponent("test-component", otherComponent);
       expect(payments.getComponent("test-component")).to.equal(otherComponent);
     });
   });
 });
 
-describe('StripePaymentsError', () => {
-  it('should be able to create an error with code and message', () => {
-    const error = new StripePaymentsError('not-found', 'test message');
+describe("StripePaymentsError", () => {
+  it("should be able to create an error with code and message", () => {
+    const error = new StripePaymentsError("not-found", "test message");
 
-    expect(error.code).to.equal('not-found');
-    expect(error.message).to.equal('test message');
+    expect(error.code).to.equal("not-found");
+    expect(error.message).to.equal("test message");
     expect(error.cause).to.be.undefined;
   });
 
-  it('should be able to create an error with code, message and cause', () => {
-    const cause = new Error('root cause');
-    const error = new StripePaymentsError('not-found', 'test message', cause);
+  it("should be able to create an error with code, message and cause", () => {
+    const cause = new Error("root cause");
+    const error = new StripePaymentsError("not-found", "test message", cause);
 
-    expect(error.code).to.equal('not-found');
-    expect(error.message).to.equal('test message');
+    expect(error.code).to.equal("not-found");
+    expect(error.message).to.equal("test message");
     expect(error.cause).to.equal(cause);
   });
 });

--- a/firestore-stripe-web-sdk/test/init.spec.ts
+++ b/firestore-stripe-web-sdk/test/init.spec.ts
@@ -16,7 +16,7 @@
 
 import { FirebaseApp } from "@firebase/app";
 import { expect } from "chai";
-import { getStripePayments, StripePayments } from "../src/index";
+import { getStripePayments, StripePayments, StripePaymentsError } from "../src/index";
 
 const app: FirebaseApp = {
   name: "mock",
@@ -33,5 +33,69 @@ describe("getStripePayments()", () => {
 
     expect(payments).to.be.instanceOf(StripePayments);
     expect(payments.app).to.equal(app);
+  });
+});
+
+describe("StripePayments", () => {
+  const payments: StripePayments = getStripePayments(app, {
+    customersCollection: "customers",
+    productsCollection: "products",
+  });
+
+  it("should expose customersCollection as a property", () => {
+    expect(payments.customersCollection).to.equal("customers");
+  });
+
+  it("should expose productsCollection as a property", () => {
+    expect(payments.productsCollection).to.equal("products");
+  });
+
+  it("should expose FirebaseApp as a property", () => {
+    expect(payments.app).to.equal(app);
+  });
+
+  describe("getComponent()", () => {
+    it("should return null when a non-existing component is requested", () => {
+      expect(payments.getComponent("non-existing")).to.be.null;
+    });
+
+    it("should return the requested component when available", () => {
+      const component: any = {};
+      payments.setComponent("test-component", component)
+
+      expect(payments.getComponent("test-component")).to.equal(component);
+    });
+  });
+
+  describe("setComponent()", () => {
+    it("should overwrite the existing component", () => {
+      const component: any = {};
+      const otherComponent: any = {other: true};
+
+      payments.setComponent("test-component", component)
+      expect(payments.getComponent("test-component")).to.equal(component);
+
+      payments.setComponent("test-component", otherComponent)
+      expect(payments.getComponent("test-component")).to.equal(otherComponent);
+    });
+  });
+});
+
+describe('StripePaymentsError', () => {
+  it('should be able to create an error with code and message', () => {
+    const error = new StripePaymentsError('not-found', 'test message');
+
+    expect(error.code).to.equal('not-found');
+    expect(error.message).to.equal('test message');
+    expect(error.cause).to.be.undefined;
+  });
+
+  it('should be able to create an error with code, message and cause', () => {
+    const cause = new Error('root cause');
+    const error = new StripePaymentsError('not-found', 'test message', cause);
+
+    expect(error.code).to.equal('not-found');
+    expect(error.message).to.equal('test message');
+    expect(error.cause).to.equal(cause);
   });
 });

--- a/firestore-stripe-web-sdk/test/product.spec.ts
+++ b/firestore-stripe-web-sdk/test/product.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Stripe, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from "@firebase/app";
+import { expect, use } from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as sinon from "sinon";
+import {
+  getProduct,
+  getStripePayments,
+  Product,
+  StripePayments,
+  StripePaymentsError,
+} from "../src/index";
+import { ProductDAO, setProductDAO } from "../src/product";
+
+use(chaiAsPromised);
+
+const app: FirebaseApp = {
+  name: "mock",
+  options: {},
+  automaticDataCollectionEnabled: false,
+};
+
+const payments: StripePayments = getStripePayments(app, {
+  customersCollection: "customers",
+  productsCollection: "products",
+});
+
+const testProduct: Product = {
+  id: "product1",
+  active: true,
+  name: "Product name",
+  description: "Product description",
+  role: "Role",
+  images: [],
+  metadata: {},
+  prices: [],
+};
+
+describe("getProduct()", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  [null, [], {}, true, 1, 0, NaN, "payments"].forEach(
+    (invalidPayments: any) => {
+      it(`should reject given invalid StripePayments: ${JSON.stringify(
+        invalidPayments
+      )}`, async () => {
+        await expect(
+          getProduct(invalidPayments, "productId")
+        ).to.be.rejectedWith(
+          "payments must be a valid StripePayments instance."
+        );
+      });
+    }
+  );
+
+  [null, [], {}, true, 1, 0, NaN, ""].forEach((invalidProductId: any) => {
+    it(`should reject given invalid productId: ${JSON.stringify(
+      invalidProductId
+    )}`, async () => {
+      await expect(getProduct(payments, invalidProductId)).to.be.rejectedWith(
+        "productId must be a non-empty string."
+      );
+    });
+  });
+
+  it("should return Product with the specified ID", async () => {
+    const fake = sinon.fake.resolves(testProduct);
+    setProductDAO(payments, testProductDAO('getProduct', fake));
+
+    const product: Product = await getProduct(payments, "product1");
+
+    expect(product).to.eql(testProduct);
+    expect(fake.callCount).to.equal(1);
+    expect(fake.calledWithExactly("product1")).to.be.ok;
+  });
+
+  it("should reject when the data access object encounters an error", async () => {
+    const error: StripePaymentsError = new StripePaymentsError(
+      "not-found",
+      "no such product"
+    );
+    const fake = sinon.fake.rejects(error);
+    setProductDAO(payments, testProductDAO('getProduct', fake));
+
+    await expect(getProduct(payments, "product1")).to.be.rejectedWith(error);
+
+    expect(fake.callCount).to.equal(1);
+    expect(fake.calledWithExactly("product1")).to.be.ok;
+  });
+});
+
+function testProductDAO(name: string, fake: sinon.SinonSpy): ProductDAO {
+  return {
+    [name]: fake,
+  } as unknown as ProductDAO;
+}

--- a/firestore-stripe-web-sdk/test/product.spec.ts
+++ b/firestore-stripe-web-sdk/test/product.spec.ts
@@ -41,9 +41,11 @@ const testProduct: Product = {
   active: true,
   name: "Product name",
   description: "Product description",
-  role: "Role",
+  role: "moderator",
   images: [],
-  metadata: {},
+  metadata: {
+    firebaseRole: "moderator",
+  },
 };
 
 describe("getProduct()", () => {
@@ -132,7 +134,7 @@ describe("getProduct()", () => {
     it("should reject with not-found error when the specified product does not exist", async () => {
       const err: any = await expect(
         getProduct(payments, "product2")
-      ).to.be.rejectedWith("no such productId");
+      ).to.be.rejectedWith("No product found with the ID: product2");
 
       expect(err).to.be.instanceOf(StripePaymentsError);
       expect(err.code).to.equal("not-found");


### PR DESCRIPTION
Adding the above APIs, where `getProduct()` reads the product information from Firestore. I'm introducing an internal `ProductDAO` interface that handles all database interactions. This allows us to easily unit test the SDK via fakes and mocks. In order to unit test the actual Firestore interactions, I'm using the Firebase emulator suite.

Additionally, I'm removing the `npm run build` step from the CI workflow, since it's already tied to a post-install hook, and runs as part of `npm i`.