### PR TITLE
feat: Added createCheckoutSession() API

### DIFF
--- a/firestore-stripe-invoices/functions/src/index.ts
+++ b/firestore-stripe-invoices/functions/src/index.ts
@@ -138,9 +138,8 @@ export const sendInvoice = functions.handler.firestore.document.onCreate(
       }
 
       // Check to see if there's a Stripe customer associated with the email address
-      let customers: Stripe.ApiList<Stripe.Customer> = await stripe.customers.list(
-        { email }
-      );
+      let customers: Stripe.ApiList<Stripe.Customer> =
+        await stripe.customers.list({ email });
       let customer: Stripe.Customer;
 
       if (customers.data.length) {
@@ -178,10 +177,10 @@ export const sendInvoice = functions.handler.firestore.document.onCreate(
 
       if (invoice) {
         // Email the invoice to the customer
-        const finalizedInvoice: Stripe.Invoice = await stripe.invoices.sendInvoice(
-          invoice.id,
-          { idempotencyKey: `invoices-sendInvoice-${eventId}` }
-        );
+        const finalizedInvoice: Stripe.Invoice =
+          await stripe.invoices.sendInvoice(invoice.id, {
+            idempotencyKey: `invoices-sendInvoice-${eventId}`,
+          });
         if (finalizedInvoice.status === 'open') {
           // Successfully emailed the invoice
           logs.invoiceSent(

--- a/firestore-stripe-subscriptions/functions/src/index.ts
+++ b/firestore-stripe-subscriptions/functions/src/index.ts
@@ -79,13 +79,13 @@ const createCustomerRecord = async ({
   }
 };
 
-exports.createCustomer = functions.auth.user().onCreate(
-  async (user): Promise<void> => {
+exports.createCustomer = functions.auth
+  .user()
+  .onCreate(async (user): Promise<void> => {
     if (!config.syncUsersOnCreate) return;
     const { email, uid } = user;
     await createCustomerRecord({ email, uid });
-  }
-);
+  });
 
 /**
  * Create a CheckoutSession for the customer so they can sign up for the subscription.
@@ -127,15 +127,16 @@ exports.createCheckoutSession = functions.firestore
       }
       const customer = customerRecord.stripeId;
       // Get shipping countries
-      const shippingCountries: Stripe.Checkout.SessionCreateParams.ShippingAddressCollection.AllowedCountry[] = collect_shipping_address
-        ? (
-            await admin
-              .firestore()
-              .collection(config.productsCollectionPath)
-              .doc('shipping_countries')
-              .get()
-          ).data()?.['allowed_countries'] ?? []
-        : [];
+      const shippingCountries: Stripe.Checkout.SessionCreateParams.ShippingAddressCollection.AllowedCountry[] =
+        collect_shipping_address
+          ? (
+              await admin
+                .firestore()
+                .collection(config.productsCollectionPath)
+                .doc('shipping_countries')
+                .get()
+            ).data()?.['allowed_countries'] ?? []
+          : [];
       const sessionCreateParams: Stripe.Checkout.SessionCreateParams = {
         billing_address_collection,
         shipping_address_collection: { allowed_countries: shippingCountries },

--- a/firestore-stripe-web-sdk/.mocharc.js
+++ b/firestore-stripe-web-sdk/.mocharc.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = {
+  require: ["ts-node/register", "jsdom-global/register"],
+  timeout: 5000,
+};

--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -7,6 +7,16 @@
 import { FirebaseApp } from '@firebase/app';
 
 // @public
+export interface CommonSessionCreateParams {
+    cancelUrl?: string;
+    mode?: "subscription" | "payment";
+    successUrl?: string;
+}
+
+// @public
+export function createCheckoutSession(payments: StripePayments, params: SessionCreateParams): Promise<Session>;
+
+// @public
 export function getPrice(payments: StripePayments, productId: string, priceId: string): Promise<Price>;
 
 // @public
@@ -49,6 +59,12 @@ export interface Price {
 }
 
 // @public
+export interface PriceIdSessionCreateParams extends CommonSessionCreateParams {
+    priceId: string;
+    quantity?: number;
+}
+
+// @public
 export interface Product {
     // (undocumented)
     readonly [propName: string]: any;
@@ -63,6 +79,21 @@ export interface Product {
     readonly prices: Price[];
     readonly role: string | null;
 }
+
+// @public
+export interface Session {
+    readonly cancelUrl: string;
+    readonly createdAt: string;
+    readonly id: string;
+    readonly mode: "subscription" | "payment";
+    readonly priceId?: string;
+    readonly quantity?: number;
+    readonly successUrl: string;
+    readonly url: string;
+}
+
+// @public
+export type SessionCreateParams = PriceIdSessionCreateParams;
 
 // @public
 export class StripePayments {
@@ -84,7 +115,7 @@ export class StripePaymentsError extends Error {
 }
 
 // @public
-export type StripePaymentsErrorCode = "not-found" | "permission-denied" | "internal";
+export type StripePaymentsErrorCode = "not-found" | "permission-denied" | "unauthenticated" | "internal";
 
 // @public
 export interface StripePaymentsOptions {

--- a/firestore-stripe-web-sdk/package.json
+++ b/firestore-stripe-web-sdk/package.json
@@ -8,8 +8,8 @@
     "api-extractor": "api-extractor run --verbose",
     "api-extractor:local": "npm run build && api-extractor run --local --verbose",
     "build": "tsc",
-    "test": "firebase emulators:exec --only firestore 'npm run test:unit'",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha -r ts-node/register test/**/*.spec.ts"
+    "test": "firebase emulators:exec --only firestore,auth --project fake-project-id 'npm run test:unit'",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha test/**/*.spec.ts"
   },
   "keywords": [
     "firebase",
@@ -30,6 +30,8 @@
     "chai-as-promised": "^7.1.1",
     "chai-like": "^1.1.1",
     "firebase-tools": "^9.18.0",
+    "jsdom": "^17.0.0",
+    "jsdom-global": "^3.0.2",
     "mocha": "^9.1.1",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -23,6 +23,14 @@ export {
 } from "./init";
 
 export {
+  createCheckoutSession,
+  CommonSessionCreateParams,
+  PriceIdSessionCreateParams,
+  Session,
+  SessionCreateParams,
+} from "./session";
+
+export {
   GetProductOptions,
   GetProductsOptions,
   Price,

--- a/firestore-stripe-web-sdk/src/init.ts
+++ b/firestore-stripe-web-sdk/src/init.ts
@@ -104,6 +104,7 @@ export class StripePayments {
 export type StripePaymentsErrorCode =
   | "not-found"
   | "permission-denied"
+  | "unauthenticated"
   | "internal";
 
 /**

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -476,7 +476,7 @@ function getOrInitProductDAO(payments: StripePayments): ProductDAO {
 }
 
 /**
- * Internal API registering a {@link ProductDAO} instance with {@link StripePayments}. Exported
+ * Internal API for registering a {@link ProductDAO} instance with {@link StripePayments}. Exported
  * for testing.
  *
  * @internal

--- a/firestore-stripe-web-sdk/src/product.ts
+++ b/firestore-stripe-web-sdk/src/product.ts
@@ -218,10 +218,8 @@ export function getProducts(
   const activeOnly: boolean = options?.activeOnly ?? false;
   return dao.getProducts({ activeOnly }).then((products: Product[]) => {
     if (options?.includePrices) {
-      const productsWithPrices: Promise<
-        Product
-      >[] = products.map((product: Product) =>
-        getProductWithPrices(dao, product)
+      const productsWithPrices: Promise<Product>[] = products.map(
+        (product: Product) => getProductWithPrices(dao, product)
       );
       return Promise.all(productsWithPrices);
     }
@@ -330,9 +328,8 @@ class FirestoreProductDAO implements ProductDAO {
   }
 
   public async getProduct(productId: string): Promise<Product> {
-    const snap: QueryDocumentSnapshot<Product> = await this.getProductSnapshotIfExists(
-      productId
-    );
+    const snap: QueryDocumentSnapshot<Product> =
+      await this.getProductSnapshotIfExists(productId);
     return snap.data();
   }
 
@@ -351,10 +348,8 @@ class FirestoreProductDAO implements ProductDAO {
   }
 
   public async getPrice(productId: string, priceId: string): Promise<Price> {
-    const snap: QueryDocumentSnapshot<Price> = await this.getPriceSnapshotIfExists(
-      productId,
-      priceId
-    );
+    const snap: QueryDocumentSnapshot<Price> =
+      await this.getPriceSnapshotIfExists(productId, priceId);
     return snap.data();
   }
 
@@ -464,9 +459,8 @@ class FirestoreProductDAO implements ProductDAO {
 const PRODUCT_DAO_KEY = "product-dao" as const;
 
 function getOrInitProductDAO(payments: StripePayments): ProductDAO {
-  let dao: ProductDAO | null = payments.getComponent<ProductDAO>(
-    PRODUCT_DAO_KEY
-  );
+  let dao: ProductDAO | null =
+    payments.getComponent<ProductDAO>(PRODUCT_DAO_KEY);
   if (!dao) {
     dao = new FirestoreProductDAO(payments.app, payments.productsCollection);
     setProductDAO(payments, dao);

--- a/firestore-stripe-web-sdk/src/session.ts
+++ b/firestore-stripe-web-sdk/src/session.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from "@firebase/app";
+import { Auth, getAuth } from "@firebase/auth";
+import {
+  addDoc,
+  collection,
+  CollectionReference,
+  DocumentData,
+  DocumentReference,
+  DocumentSnapshot,
+  Firestore,
+  FirestoreDataConverter,
+  FirestoreError,
+  getFirestore,
+  onSnapshot,
+  QueryDocumentSnapshot,
+  Timestamp,
+  Unsubscribe,
+} from "@firebase/firestore";
+import { StripePaymentsError } from ".";
+import { StripePayments } from "./init";
+import { checkNonEmptyString, checkPositiveNumber } from "./utils";
+
+/**
+ * Parameters common across all session types.
+ */
+export interface CommonSessionCreateParams {
+  /**
+   * The URL the customer will be directed to if they decide to cancel payment and return to
+   * your website.
+   */
+  cancelUrl?: string;
+
+  /**
+   * The mode of the Checkout Session. If not specified defaults to `subscription`.
+   */
+  mode?: "subscription" | "payment";
+
+  /**
+   * The URL to which Stripe should send customers when payment or setup is complete.
+   */
+  successUrl?: string;
+}
+
+/**
+ * Parameters for createing a session with a Stripe price ID.
+ */
+export interface PriceIdSessionCreateParams extends CommonSessionCreateParams {
+  /**
+   * The ID of the Stripe price.
+   */
+  priceId: string;
+
+  /**
+   * The quantity of the item being purchased. Defaults to 1.
+   */
+  quantity?: number;
+}
+
+/**
+ * Parameters for creating a new session.
+ */
+export type SessionCreateParams = PriceIdSessionCreateParams;
+
+/**
+ * Interface of Stripe checkout session.
+ */
+export interface Session {
+  /**
+   * The URL the customer will be directed to if they decide to cancel payment and return to
+   * your website.
+   */
+  readonly cancelUrl: string;
+
+  /**
+   * Time when the session was created as a UTC timestamp.
+   */
+  readonly createdAt: string;
+
+  /**
+   * Unique identifier for the session. Used to pass to `redirectToCheckout()` in Stripe.js.
+   */
+  readonly id: string;
+
+  /**
+   * The mode of the Checkout Session.
+   */
+  readonly mode: "subscription" | "payment";
+
+  /**
+   * The URL to which Stripe should send customers when payment or setup is complete.
+   */
+  readonly successUrl: string;
+
+  /**
+   * The URL to the Checkout Session. Redirect the user to this URL to complete the payment.
+   */
+  readonly url: string;
+
+  /**
+   * The ID of the Stripe price object purchased with this session.
+   */
+  readonly priceId?: string;
+
+  /**
+   * The quantity of item purchased. Defaults to 1.
+   */
+  readonly quantity?: number;
+}
+
+/**
+ * Creates a new Stripe checkout session with the given parameters. Returned session contains a
+ * session ID and a session URL that can be used to redirect the user to complete the checkout.
+ *
+ * @param payments - A valid {@link StripePayments} object.
+ * @param params - Parameters of the checkout session.
+ * @returns Resolves with the created Stripe Session object.
+ */
+export function createCheckoutSession(
+  payments: StripePayments,
+  params: SessionCreateParams
+): Promise<Session> {
+  checkSessionCreateParams(params);
+  const dao: SessionDAO = getOrInitSessionDAO(payments);
+  return dao.createCheckoutSession(params);
+}
+
+function checkSessionCreateParams(params: SessionCreateParams): void {
+  if (typeof params.cancelUrl !== "undefined") {
+    checkNonEmptyString(
+      params.cancelUrl,
+      "cancelUrl must be a non-empty string."
+    );
+  }
+
+  if (typeof params.successUrl !== "undefined") {
+    checkNonEmptyString(
+      params.successUrl,
+      "successUrl must be a non-empty string."
+    );
+  }
+
+  checkNonEmptyString(params.priceId, "priceId must be a non-empty string.");
+  if (typeof params.quantity !== "undefined") {
+    checkPositiveNumber(
+      params.quantity,
+      "quantity must be a positive integer."
+    );
+  }
+}
+
+export interface SessionDAO {
+  createCheckoutSession(params: SessionCreateParams): Promise<Session>;
+}
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+type MutableSession = Mutable<Partial<Session>>;
+
+class FirestoreSessionDAO implements SessionDAO {
+  private readonly auth: Auth;
+  private readonly firestore: Firestore;
+
+  constructor(app: FirebaseApp, private readonly customersCollection: string) {
+    this.auth = getAuth(app);
+    this.firestore = getFirestore(app);
+  }
+
+  public async createCheckoutSession(
+    params: SessionCreateParams
+  ): Promise<Session> {
+    const currentUser: string | undefined = this.auth.currentUser?.uid;
+    if (!currentUser) {
+      throw new StripePaymentsError(
+        "unauthenticated",
+        "Failed to determine currently signed in user. User not signed in."
+      );
+    }
+
+    const sessions: CollectionReference<MutableSession> = collection(
+      this.firestore,
+      this.customersCollection,
+      currentUser,
+      "checkout_sessions"
+    ).withConverter(SESSION_CONVERTER);
+    try {
+      const doc: DocumentReference<MutableSession> = await addDoc(
+        sessions,
+        params
+      );
+      return await this.waitForSessionId(doc);
+    } catch (err) {
+      throw new StripePaymentsError(
+        "internal",
+        "Error while querying Firestore.",
+        err
+      );
+    }
+  }
+
+  private waitForSessionId(
+    doc: DocumentReference<MutableSession>
+  ): Promise<Session> {
+    let cancel: Unsubscribe;
+    return new Promise<Session>((resolve, reject) => {
+      cancel = onSnapshot(
+        doc,
+        (snap: DocumentSnapshot<MutableSession>) => {
+          const session: MutableSession | undefined = snap.data();
+          if (hasSessionId(session)) {
+            resolve(session);
+          }
+        },
+        (err: FirestoreError) => {
+          reject(err);
+        }
+      );
+    }).finally(() => cancel());
+  }
+}
+
+function hasSessionId(session: MutableSession | undefined): session is Session {
+  return !!session && "id" in session;
+}
+
+const SESSION_CONVERTER: FirestoreDataConverter<MutableSession> = {
+  toFirestore: (session: MutableSession): DocumentData => {
+    const data: DocumentData = {
+      cancel_url: session.cancelUrl ?? window.location.href,
+      mode: session.mode ?? "subscription",
+      price: session.priceId,
+      success_url: session.successUrl ?? window.location.href,
+    };
+
+    if (typeof session.quantity !== "undefined") {
+      data.quantity = session.quantity;
+    }
+
+    return data;
+  },
+  fromFirestore: (snapshot: QueryDocumentSnapshot): MutableSession => {
+    const data: DocumentData = snapshot.data();
+    const session: Partial<Mutable<Session>> = {
+      cancelUrl: data.cancel_url,
+      mode: data.mode,
+      successUrl: data.success_url,
+      priceId: data.price,
+    };
+
+    if (typeof data.created !== "undefined") {
+      session.createdAt = toUTCDateString(data.created);
+    }
+
+    if (typeof data.quantity !== "undefined") {
+      session.quantity = data.quantity;
+    }
+
+    if (typeof data.sessionId !== "undefined") {
+      session.id = data.sessionId;
+    }
+
+    if (typeof data.url !== "undefined") {
+      session.url = data.url;
+    }
+
+    return session;
+  },
+};
+
+function toUTCDateString(timestamp: Timestamp): string {
+  return timestamp.toDate().toUTCString();
+}
+
+const SESSION_DAO_KEY = "checkout-session-dao" as const;
+
+function getOrInitSessionDAO(payments: StripePayments): SessionDAO {
+  let dao: SessionDAO | null = payments.getComponent<SessionDAO>(
+    SESSION_DAO_KEY
+  );
+  if (!dao) {
+    dao = new FirestoreSessionDAO(payments.app, payments.customersCollection);
+    setSessionDAO(payments, dao);
+  }
+
+  return dao;
+}
+
+/**
+ * Internal API for registering a {@link SessionDAO} instance with {@link StripePayments}.
+ * Exported for testing.
+ *
+ * @internal
+ */
+export function setSessionDAO(payments: StripePayments, dao: SessionDAO): void {
+  payments.setComponent(SESSION_DAO_KEY, dao);
+}

--- a/firestore-stripe-web-sdk/src/session.ts
+++ b/firestore-stripe-web-sdk/src/session.ts
@@ -134,21 +134,14 @@ export function createCheckoutSession(
   payments: StripePayments,
   params: SessionCreateParams
 ): Promise<Session> {
-  params = checkAndUpdateParams(params);
+  params = { ...params };
+  checkAndUpdateCommonParams(params);
+  checkAndUpdatePriceIdParams(params);
   const dao: SessionDAO = getOrInitSessionDAO(payments);
   return dao.createCheckoutSession(params);
 }
 
-function checkAndUpdateParams(
-  params: SessionCreateParams
-): SessionCreateParams {
-  params = { ...params };
-  checkAndUpdateCommonParams(params);
-  checkAndUpdatePriceIdParams(params);
-  return params;
-}
-
-function checkAndUpdateCommonParams(params: SessionCreateParams) {
+function checkAndUpdateCommonParams(params: SessionCreateParams): void {
   if (typeof params.cancelUrl !== "undefined") {
     checkNonEmptyString(
       params.cancelUrl,
@@ -169,7 +162,7 @@ function checkAndUpdateCommonParams(params: SessionCreateParams) {
   }
 }
 
-function checkAndUpdatePriceIdParams(params: PriceIdSessionCreateParams) {
+function checkAndUpdatePriceIdParams(params: PriceIdSessionCreateParams): void {
   checkNonEmptyString(params.priceId, "priceId must be a non-empty string.");
   if (typeof params.quantity !== "undefined") {
     checkPositiveNumber(

--- a/firestore-stripe-web-sdk/src/utils.ts
+++ b/firestore-stripe-web-sdk/src/utils.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { StripePayments } from "./init";
-
-export function checkNonEmptyString(arg: string, message?: string): void {
+export function checkNonEmptyString(arg: unknown, message?: string): void {
   if (typeof arg !== "string" || arg === "") {
     throw new Error(message ?? "arg must be a non-empty string.");
+  }
+}
+
+export function checkPositiveNumber(arg: unknown, message?: string): void {
+  if (typeof arg !== "number" || isNaN(arg) || arg <= 0) {
+    throw new Error(message ?? "arg must be positive number.");
   }
 }

--- a/firestore-stripe-web-sdk/test/product.spec.ts
+++ b/firestore-stripe-web-sdk/test/product.spec.ts
@@ -365,10 +365,10 @@ function testProductDAO(
   fake?: SinonSpy
 ): ProductDAO {
   if (typeof nameOrFakes === "string") {
-    return ({
+    return {
       [nameOrFakes]: fake,
-    } as unknown) as ProductDAO;
+    } as unknown as ProductDAO;
   }
 
-  return (nameOrFakes as unknown) as ProductDAO;
+  return nameOrFakes as unknown as ProductDAO;
 }

--- a/firestore-stripe-web-sdk/test/session.spec.ts
+++ b/firestore-stripe-web-sdk/test/session.spec.ts
@@ -96,7 +96,12 @@ describe("createCheckoutSession()", () => {
     });
 
     expect(session).to.eql(testSession);
-    expect(fake).to.have.been.calledOnceWithExactly({ priceId: "price1" });
+    expect(fake).to.have.been.calledOnceWithExactly({
+      cancelUrl: window.location.href,
+      mode: "subscription",
+      priceId: "price1",
+      successUrl: window.location.href,
+    });
   });
 
   it("should return a session when called with all valid parameters", async () => {
@@ -128,12 +133,12 @@ describe("createCheckoutSession()", () => {
       createCheckoutSession(payments, { priceId: "price1" })
     ).to.be.rejectedWith(error);
 
-    expect(fake).to.have.been.calledOnceWithExactly({ priceId: "price1" });
+    expect(fake).to.have.been.calledOnce;
   });
 });
 
 function testSessionDAO(name: string, fake: SinonSpy): SessionDAO {
-  return ({
+  return {
     [name]: fake,
-  } as unknown) as SessionDAO;
+  } as unknown as SessionDAO;
 }

--- a/firestore-stripe-web-sdk/test/session.spec.ts
+++ b/firestore-stripe-web-sdk/test/session.spec.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, use } from "chai";
+import { fake as sinonFake, SinonSpy } from "sinon";
+import { FirebaseApp } from "@firebase/app";
+import {
+  createCheckoutSession,
+  getStripePayments,
+  Session,
+  SessionCreateParams,
+  StripePayments,
+  StripePaymentsError,
+} from "../src/index";
+import { SessionDAO, setSessionDAO } from "../src/session";
+
+use(require("chai-as-promised"));
+use(require("sinon-chai"));
+
+const app: FirebaseApp = {
+  name: "mock",
+  options: {},
+  automaticDataCollectionEnabled: false,
+};
+
+const payments: StripePayments = getStripePayments(app, {
+  customersCollection: "customers",
+  productsCollection: "products",
+});
+
+const testSession: Session = {
+  cancelUrl: "https://example.com/cancel",
+  createdAt: new Date().toUTCString(),
+  id: "test_session_1",
+  mode: "subscription",
+  priceId: "price1",
+  successUrl: "https://example.com/success",
+  url: "https://example.stripe.com/session/test_session_1",
+};
+
+describe("createCheckoutSession()", () => {
+  const invalidUrls: any[] = [null, [], {}, true, 1, 0, NaN, ""];
+
+  invalidUrls.forEach((cancelUrl: any) => {
+    it(`should throw when called with invalid cancelUrl: ${cancelUrl}`, () => {
+      expect(() =>
+        createCheckoutSession(payments, {
+          cancelUrl,
+          priceId: "price1",
+        })
+      ).to.throw("cancelUrl must be a non-empty string.");
+    });
+  });
+
+  invalidUrls.forEach((successUrl: any) => {
+    it(`should throw when called with invalid successUrl: ${successUrl}`, () => {
+      expect(() =>
+        createCheckoutSession(payments, {
+          successUrl,
+          priceId: "price1",
+        })
+      ).to.throw("successUrl must be a non-empty string.");
+    });
+  });
+
+  [null, [], {}, true, -1, 0, NaN, ""].forEach((quantity: any) => {
+    it(`should throw when called with invalid quantity: ${quantity}`, () => {
+      expect(() =>
+        createCheckoutSession(payments, {
+          quantity,
+          priceId: "price1",
+        })
+      ).to.throw("quantity must be a positive integer.");
+    });
+  });
+
+  it("should return a session when called with minimum valid parameters", async () => {
+    const fake: SinonSpy = sinonFake.resolves(testSession);
+    setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
+
+    const session: Session = await createCheckoutSession(payments, {
+      priceId: "price1",
+    });
+
+    expect(session).to.eql(testSession);
+    expect(fake).to.have.been.calledOnceWithExactly({ priceId: "price1" });
+  });
+
+  it("should return a session when called with all valid parameters", async () => {
+    const fake: SinonSpy = sinonFake.resolves(testSession);
+    setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
+    const params: SessionCreateParams = {
+      cancelUrl: "https://example.com/cancel",
+      mode: "subscription",
+      priceId: "price1",
+      quantity: 5,
+      successUrl: "https://example.com/success",
+    };
+
+    const session: Session = await createCheckoutSession(payments, params);
+
+    expect(session).to.eql(testSession);
+    expect(fake).to.have.been.calledOnceWithExactly(params);
+  });
+
+  it("should reject when the data access object throws", async () => {
+    const error: StripePaymentsError = new StripePaymentsError(
+      "internal",
+      "failed to create session"
+    );
+    const fake: SinonSpy = sinonFake.rejects(error);
+    setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
+
+    await expect(
+      createCheckoutSession(payments, { priceId: "price1" })
+    ).to.be.rejectedWith(error);
+
+    expect(fake).to.have.been.calledOnceWithExactly({ priceId: "price1" });
+  });
+});
+
+function testSessionDAO(name: string, fake: SinonSpy): SessionDAO {
+  return ({
+    [name]: fake,
+  } as unknown) as SessionDAO;
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "lerna": "^3.4.3",
-    "prettier": "2.0.5"
+    "prettier": "^2.4.1"
   }
 }


### PR DESCRIPTION
Added `createCheckoutSession()` API. To keep this PR simple, I'm only adding a few of the parameters supported.

I'm also renaming the integration test suite file to `emulator.spec.ts`, and using it to place all integration tests for now. In a future PR I might move it to a separate directory separate from unit tests, and split it into a bunch of smaller files.

I also had to upgrade prettier to the latest version since the old version did not support logical nullish assignment operator (`??=`), which I wanted to use in my code. Couple of other source files in the repo also got slightly updated as a result.