### PR TITLE
feat: Added support for configurable timeouts

### DIFF
--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -13,8 +13,16 @@ export interface CommonSessionCreateParams {
     successUrl?: string;
 }
 
+// @public (undocumented)
+export const CREATE_SESSION_TIMEOUT_MILLIS: number;
+
 // @public
-export function createCheckoutSession(payments: StripePayments, params: SessionCreateParams): Promise<Session>;
+export function createCheckoutSession(payments: StripePayments, params: SessionCreateParams, options?: CreateCheckoutSessionOptions): Promise<Session>;
+
+// @public
+export interface CreateCheckoutSessionOptions {
+    timeoutMillis?: number;
+}
 
 // @public
 export function getPrice(payments: StripePayments, productId: string, priceId: string): Promise<Price>;
@@ -115,7 +123,7 @@ export class StripePaymentsError extends Error {
 }
 
 // @public
-export type StripePaymentsErrorCode = "not-found" | "permission-denied" | "unauthenticated" | "internal";
+export type StripePaymentsErrorCode = "deadline-exceeded" | "not-found" | "permission-denied" | "unauthenticated" | "internal";
 
 // @public
 export interface StripePaymentsOptions {

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -23,7 +23,9 @@ export {
 } from "./init";
 
 export {
+  CREATE_SESSION_TIMEOUT_MILLIS,
   createCheckoutSession,
+  CreateCheckoutSessionOptions,
   CommonSessionCreateParams,
   PriceIdSessionCreateParams,
   Session,

--- a/firestore-stripe-web-sdk/src/init.ts
+++ b/firestore-stripe-web-sdk/src/init.ts
@@ -102,6 +102,7 @@ export class StripePayments {
  * Union of possible error codes.
  */
 export type StripePaymentsErrorCode =
+  | "deadline-exceeded"
   | "not-found"
   | "permission-denied"
   | "unauthenticated"

--- a/firestore-stripe-web-sdk/src/user.ts
+++ b/firestore-stripe-web-sdk/src/user.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirebaseApp } from "@firebase/app";
+import { Auth, getAuth } from "@firebase/auth";
+import { StripePayments, StripePaymentsError } from "./init";
+
+/**
+ * Internal API for retrieving the currently signed in user. Rejects with "unauthenticated" if
+ * the user is not signed in. Exposed for internal use.
+ *
+ * @internal
+ */
+export function getCurrentUser(payments: StripePayments): Promise<string> {
+  const dao: UserDAO = getOrInitUserDAO(payments);
+  return dao.getCurrentUser();
+}
+
+/**
+ * Internal interface for introspecting the current user's login session. Exposed for testing.
+ *
+ * @internal
+ */
+export interface UserDAO {
+  getCurrentUser(): Promise<string>;
+}
+
+class FirebaseAuthUserDAO implements UserDAO {
+  private readonly auth: Auth;
+
+  constructor(app: FirebaseApp) {
+    this.auth = getAuth(app);
+  }
+
+  public getCurrentUser(): Promise<string> {
+    const currentUser: string | undefined = this.auth.currentUser?.uid;
+    if (!currentUser) {
+      return Promise.reject(
+        new StripePaymentsError(
+          "unauthenticated",
+          "Failed to determine currently signed in user. User not signed in."
+        )
+      );
+    }
+
+    return Promise.resolve(currentUser);
+  }
+}
+
+const USER_DAO_KEY = "user-dao" as const;
+
+function getOrInitUserDAO(payments: StripePayments): UserDAO {
+  let dao: UserDAO | null = payments.getComponent<UserDAO>(USER_DAO_KEY);
+  if (!dao) {
+    dao = new FirebaseAuthUserDAO(payments.app);
+    setUserDAO(payments, dao);
+  }
+
+  return dao;
+}
+
+/**
+ * Internal API for registering a {@link UserDAO} instance with {@link StripePayments}.
+ * Exported for testing.
+ *
+ * @internal
+ */
+export function setUserDAO(payments: StripePayments, dao: UserDAO): void {
+  payments.setComponent(USER_DAO_KEY, dao);
+}

--- a/firestore-stripe-web-sdk/test/emulator.spec.ts
+++ b/firestore-stripe-web-sdk/test/emulator.spec.ts
@@ -187,6 +187,23 @@ describe("Emulator tests", () => {
           success_url: "https://example.com/success",
         });
       });
+
+      it("rejects with deadline-exceeded when the timeout has expired", async () => {
+        // Teardown the trigger so the session will never get created.
+        await backend.tearDown();
+
+        const err: any = await expect(
+          createCheckoutSession(
+            payments,
+            { priceId: "foo" },
+            { timeoutMillis: 10 }
+          )
+        ).to.be.rejectedWith("Timeout while waiting for session response.");
+
+        expect(err).to.be.instanceOf(StripePaymentsError);
+        expect(err.code).to.equal("deadline-exceeded");
+        expect(err.cause).to.be.undefined;
+      });
     });
   });
 

--- a/firestore-stripe-web-sdk/test/emulator.spec.ts
+++ b/firestore-stripe-web-sdk/test/emulator.spec.ts
@@ -189,7 +189,8 @@ describe("Emulator tests", () => {
       });
 
       it("rejects with deadline-exceeded when the timeout has expired", async () => {
-        // Teardown the trigger so the session will never get created.
+        // Backend trigger is already initialized above in beforeEach.
+        // Teardown it here so the session will never get created.
         await backend.tearDown();
 
         const err: any = await expect(


### PR DESCRIPTION
Added support for passing a timeout to the `createCheckoutSession()` function. Defaults to 30 seconds.

Also the `FirestoreSessionDAO` class currently deals with checking current user session. Since this logic is required in several other places, I'm refactoring it into a new `UserDAO` interface.