### PR TITLE
feat: Added onCurrentUserSubscriptionUpdate() API

### DIFF
--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -62,7 +62,7 @@ export interface GetSubscriptionsOptions {
 }
 
 // @public
-export function onCurrentUserSubscriptionUpdate(payments: StripePayments, onUpdate: (snapshot: Subscription[]) => void, onError?: (error: StripePaymentsError) => void): () => void;
+export function onCurrentUserSubscriptionUpdate(payments: StripePayments, onUpdate: (snapshot: SubscriptionSnapshot) => void, onError?: (error: StripePaymentsError) => void): () => void;
 
 // @public
 export interface Price {
@@ -175,6 +175,24 @@ export interface Subscription {
     readonly trialEnd: string | null;
     readonly trialStart: string | null;
     readonly uid: string;
+}
+
+// @public (undocumented)
+export type SubscriptionChange = "added" | "modified" | "removed";
+
+// @public (undocumented)
+export interface SubscriptionSnapshot {
+    // (undocumented)
+    changes: Array<{
+        type: SubscriptionChange;
+        subscription: Subscription;
+    }>;
+    // (undocumented)
+    empty: boolean;
+    // (undocumented)
+    size: number;
+    // (undocumented)
+    subscriptions: Subscription[];
 }
 
 // @public

--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -62,6 +62,9 @@ export interface GetSubscriptionsOptions {
 }
 
 // @public
+export function onCurrentUserSubscriptionUpdate(payments: StripePayments, onUpdate: (snapshot: Subscription[]) => void, onError?: (error: StripePaymentsError) => void): () => void;
+
+// @public
 export interface Price {
     // (undocumented)
     readonly [propName: string]: any;

--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments-js.api.md
@@ -177,21 +177,17 @@ export interface Subscription {
     readonly uid: string;
 }
 
-// @public (undocumented)
-export type SubscriptionChange = "added" | "modified" | "removed";
+// @public
+export type SubscriptionChangeType = "added" | "modified" | "removed";
 
-// @public (undocumented)
+// @public
 export interface SubscriptionSnapshot {
-    // (undocumented)
     changes: Array<{
-        type: SubscriptionChange;
+        type: SubscriptionChangeType;
         subscription: Subscription;
     }>;
-    // (undocumented)
     empty: boolean;
-    // (undocumented)
     size: number;
-    // (undocumented)
     subscriptions: Subscription[];
 }
 

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   getCurrentUserSubscription,
   getCurrentUserSubscriptions,
+  onCurrentUserSubscriptionUpdate,
   GetSubscriptionsOptions,
   Subscription,
   SubscriptionStatus,

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -49,7 +49,7 @@ export {
   onCurrentUserSubscriptionUpdate,
   GetSubscriptionsOptions,
   Subscription,
-  SubscriptionChange,
+  SubscriptionChangeType,
   SubscriptionSnapshot,
   SubscriptionStatus,
 } from "./subscription";

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -49,5 +49,7 @@ export {
   onCurrentUserSubscriptionUpdate,
   GetSubscriptionsOptions,
   Subscription,
+  SubscriptionChange,
+  SubscriptionSnapshot,
   SubscriptionStatus,
 } from "./subscription";

--- a/firestore-stripe-web-sdk/src/subscription.ts
+++ b/firestore-stripe-web-sdk/src/subscription.ts
@@ -218,15 +218,38 @@ export function getCurrentUserSubscriptions(
   });
 }
 
-export type SubscriptionChange = "added" | "modified" | "removed";
+/**
+ * Different types of changes that may occur on a subscription object.
+ */
+export type SubscriptionChangeType = "added" | "modified" | "removed";
 
+/**
+ * Represents the current state of a set of subscriptions owned by a user.
+ */
 export interface SubscriptionSnapshot {
+  /**
+   * A list of all currently available subscriptions ordered by the subscription ID. Empty
+   * if no subscriptions are available.
+   */
   subscriptions: Subscription[];
+
+  /**
+   * The list of changes in the subscriptions since the last snapshot.
+   */
   changes: Array<{
-    type: SubscriptionChange;
+    type: SubscriptionChangeType;
     subscription: Subscription;
   }>;
+
+  /**
+   * Number of currently available subscriptions.
+   */
   size: number;
+
+  /**
+   * True if there are no subscriptions available. False whenever at least one subscription is
+   * present.
+   */
   empty: boolean;
 }
 
@@ -238,9 +261,6 @@ export interface SubscriptionSnapshot {
  * Upon successful registration, the `onUpdate` callback will fire once with
  * the current state of all the subscriptions. From then onwards, each update to a subscription
  * will fire the `onUpdate` callback with the latest state of the subscriptions.
- * Subscriptions array passed into the `onUpdate` callback are ordered by the subscription ID.
- * If no subscriptions are available for the current user, the callback will receive an empty
- * array.
  *
  * @param payments - A valid {@link StripePayments} object.
  * @param onUpdate - A callback that will fire whenever the current user's subscriptions

--- a/firestore-stripe-web-sdk/test/session.spec.ts
+++ b/firestore-stripe-web-sdk/test/session.spec.ts
@@ -107,7 +107,7 @@ describe("createCheckoutSession()", () => {
   it("should return a session when called with minimum valid parameters", async () => {
     const fake: SinonSpy = sinonFake.resolves(testSession);
     setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const session: Session = await createCheckoutSession(payments, {
@@ -131,7 +131,7 @@ describe("createCheckoutSession()", () => {
   it("should return a session when called with all valid parameters", async () => {
     const fake: SinonSpy = sinonFake.resolves(testSession);
     setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
     const params: SessionCreateParams = {
       cancelUrl: "https://example.com/cancel",
@@ -155,7 +155,7 @@ describe("createCheckoutSession()", () => {
   it("should return a session when called with valid timeout", async () => {
     const fake: SinonSpy = sinonFake.resolves(testSession);
     setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const session: Session = await createCheckoutSession(
@@ -187,7 +187,7 @@ describe("createCheckoutSession()", () => {
     );
     const fake: SinonSpy = sinonFake.rejects(error);
     setSessionDAO(payments, testSessionDAO("createCheckoutSession", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(
@@ -203,7 +203,7 @@ describe("createCheckoutSession()", () => {
       "unauthenticated",
       "user not signed in"
     );
-    const userFake: SinonSpy = sinonFake.rejects(error);
+    const userFake: SinonSpy = sinonFake.throws(error);
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(

--- a/firestore-stripe-web-sdk/test/subscription.spec.ts
+++ b/firestore-stripe-web-sdk/test/subscription.spec.ts
@@ -21,12 +21,17 @@ import {
   getCurrentUserSubscription,
   getCurrentUserSubscriptions,
   getStripePayments,
+  onCurrentUserSubscriptionUpdate,
   Subscription,
   StripePayments,
   StripePaymentsError,
 } from "../src/index";
 import { subscription1, subscription2 } from "./testdata";
-import { setSubscriptionDAO, SubscriptionDAO } from "../src/subscription";
+import {
+  setSubscriptionDAO,
+  SubscriptionDAO,
+  SubscriptionSnapshot,
+} from "../src/subscription";
 import { setUserDAO, UserDAO } from "../src/user";
 
 use(require("chai-as-promised"));
@@ -212,6 +217,70 @@ describe("getCurrentUserSubscriptions()", () => {
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(getCurrentUserSubscriptions(payments)).to.be.rejectedWith(
+      error
+    );
+
+    expect(userFake).to.have.been.calledOnce;
+  });
+});
+
+describe("onCurrentUserSubscriptionUpdate()", () => {
+  it("should register a callback to receive subscription updates", () => {
+    let canceled: boolean = false;
+    const fake: SinonSpy = sinonFake.returns(() => {
+      canceled = true;
+    });
+    setSubscriptionDAO(
+      payments,
+      testSubscriptionDAO("onSubscriptionUpdate", fake)
+    );
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+    const onUpdate: (snap: SubscriptionSnapshot) => void = () => {};
+
+    const cancel = onCurrentUserSubscriptionUpdate(payments, onUpdate);
+    cancel();
+
+    expect(canceled).to.be.true;
+    expect(fake).to.have.been.calledOnceWithExactly(
+      "alice",
+      onUpdate,
+      undefined
+    );
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  it("should register a callback to receive errors when specified", () => {
+    let canceled: boolean = false;
+    const fake: SinonSpy = sinonFake.returns(() => {
+      canceled = true;
+    });
+    setSubscriptionDAO(
+      payments,
+      testSubscriptionDAO("onSubscriptionUpdate", fake)
+    );
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+    const onUpdate: (snap: SubscriptionSnapshot) => void = () => {};
+    const onError: (err: StripePaymentsError) => void = () => {};
+
+    const cancel = onCurrentUserSubscriptionUpdate(payments, onUpdate, onError);
+    cancel();
+
+    expect(canceled).to.be.true;
+    expect(fake).to.have.been.calledOnceWithExactly("alice", onUpdate, onError);
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  it("should throw when the user data access object throws", () => {
+    const error: StripePaymentsError = new StripePaymentsError(
+      "unauthenticated",
+      "user not signed in"
+    );
+    const userFake: SinonSpy = sinonFake.throws(error);
+    setUserDAO(payments, testUserDAO(userFake));
+
+    expect(() => onCurrentUserSubscriptionUpdate(payments, () => {})).to.throw(
       error
     );
 

--- a/firestore-stripe-web-sdk/test/subscription.spec.ts
+++ b/firestore-stripe-web-sdk/test/subscription.spec.ts
@@ -58,7 +58,7 @@ describe("getCurrentUserSubscription()", () => {
     const expected: Subscription = { ...subscription1, uid: "alice" };
     const fake: SinonSpy = sinonFake.resolves(expected);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscription", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const subscription: Subscription = await getCurrentUserSubscription(
@@ -78,7 +78,7 @@ describe("getCurrentUserSubscription()", () => {
     );
     const fake: SinonSpy = sinonFake.rejects(error);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscription", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(
@@ -94,7 +94,7 @@ describe("getCurrentUserSubscription()", () => {
       "unauthenticated",
       "user not signed in"
     );
-    const userFake: SinonSpy = sinonFake.rejects(error);
+    const userFake: SinonSpy = sinonFake.throws(error);
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(
@@ -109,7 +109,7 @@ describe("getCurrentUserSubscriptions()", () => {
   it("should return all subscriptions when called without options", async () => {
     const fake: SinonSpy = sinonFake.resolves([subscription1, subscription2]);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscriptions", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const subscriptions: Subscription[] = await getCurrentUserSubscriptions(
@@ -136,7 +136,7 @@ describe("getCurrentUserSubscriptions()", () => {
   it("should only return subscriptions with the given status", async () => {
     const fake: SinonSpy = sinonFake.resolves([subscription1]);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscriptions", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const subscriptions: Subscription[] = await getCurrentUserSubscriptions(
@@ -156,7 +156,7 @@ describe("getCurrentUserSubscriptions()", () => {
   it("should only return subscriptions with the given statuses", async () => {
     const fake: SinonSpy = sinonFake.resolves([subscription1, subscription2]);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscriptions", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     const subscriptions: Subscription[] = await getCurrentUserSubscriptions(
@@ -192,7 +192,7 @@ describe("getCurrentUserSubscriptions()", () => {
     );
     const fake: SinonSpy = sinonFake.rejects(error);
     setSubscriptionDAO(payments, testSubscriptionDAO("getSubscriptions", fake));
-    const userFake: SinonSpy = sinonFake.resolves("alice");
+    const userFake: SinonSpy = sinonFake.returns("alice");
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(getCurrentUserSubscriptions(payments)).to.be.rejectedWith(
@@ -208,7 +208,7 @@ describe("getCurrentUserSubscriptions()", () => {
       "unauthenticated",
       "user not signed in"
     );
-    const userFake: SinonSpy = sinonFake.rejects(error);
+    const userFake: SinonSpy = sinonFake.throws(error);
     setUserDAO(payments, testUserDAO(userFake));
 
     await expect(getCurrentUserSubscriptions(payments)).to.be.rejectedWith(

--- a/firestore-stripe-web-sdk/test/testdata.ts
+++ b/firestore-stripe-web-sdk/test/testdata.ts
@@ -175,11 +175,6 @@ export const rawProductData: Record<string, ProductData> = {
   },
 };
 
-export interface SubscriptionData {
-  uid: string;
-  subscriptions: Record<string, Record<string, any>>;
-}
-
 export const subscription1: Subscription = {
   cancelAt: null,
   cancelAtPeriodEnd: true,
@@ -263,7 +258,9 @@ export const subscription3: Subscription = {
   uid: "dynamic",
 };
 
-export const rawSubscriptionData: Record<string, Record<string, any>> = {
+export type SubscriptionData = Record<string, Record<string, any>>;
+
+export const rawSubscriptionData: SubscriptionData = {
   sub1: {
     cancel_at: null,
     cancel_at_period_end: true,


### PR DESCRIPTION
I took a slightly different approach than originally planned. Instead of firing the update callback with a `Subscription[]` array, I introduced a new `SubscriptionSnapshot` type, that closely maps to the underlying Firestore snapshot type. In addition to the array, it also exposes `changes`,`size` and `empty` fields, which may be useful to some developers.

Other changes in this PR:
* Changed `UserDAO.getCurrentUser()` method into a synchronous one, since we need to call it from the new `onCurrentUserSubscriptionUpdate()` function.
* Using Firestore batch writes in emulator tests to update/write multiple documents together.
