### PR TITLE
chore: Run tests in real browser

### DIFF
--- a/firestore-stripe-web-sdk/karma.conf.js
+++ b/firestore-stripe-web-sdk/karma.conf.js
@@ -1,0 +1,68 @@
+const karma = require('karma');
+const webpackTestConfig = require('./webpack.test');
+
+const config = {
+  // files to load into karma
+  files: ['test/**/*.ts', 'src/**/*.ts'],
+
+  // frameworks to use
+  // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+  frameworks: ['mocha'],
+
+  // Doing 65 seconds to allow for the 20 second firestore tests
+  browserNoActivityTimeout: 65000,
+
+  // preprocess matching files before serving them to the browser
+  // available preprocessors:
+  // https://npmjs.org/browse/keyword/karma-preprocessor
+  preprocessors: {
+    '**/*.ts': ['webpack', 'sourcemap']
+  },
+
+  mime: { 'text/x-typescript': ['ts', 'tsx'] },
+
+  // test results reporter to use
+  // possible values: 'dots', 'progress', 'coverage-istanbul'
+  // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+  reporters: ['mocha'],
+
+  // web server port
+  port: 8089,
+
+  // enable / disable colors in the output (reporters and logs)
+  colors: true,
+
+  // level of logging
+  // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN
+  // || config.LOG_INFO || config.LOG_DEBUG
+  logLevel: karma.constants.LOG_INFO,
+
+  // enable / disable watching file and executing tests whenever any file
+  // changes
+  autoWatch: false,
+
+  // start these browsers
+  // available browser launchers:
+  // https://npmjs.org/browse/keyword/karma-launcher
+  browsers: ['ChromeHeadless'],
+
+  webpack: webpackTestConfig,
+
+  webpackMiddleware: { quiet: true, stats: { colors: true } },
+
+  singleRun: false,
+
+  client: {
+    mocha: {
+      timeout: 5000
+    }
+  },
+
+  mochaReporter: {
+    showDiff: true
+  }
+};
+
+module.exports = function(karmaConfig){
+  karmaConfig.set(config);
+};

--- a/firestore-stripe-web-sdk/karma.conf.js
+++ b/firestore-stripe-web-sdk/karma.conf.js
@@ -1,13 +1,13 @@
-const karma = require('karma');
-const webpackTestConfig = require('./webpack.test');
+const karma = require("karma");
+const webpackTestConfig = require("./webpack.test");
 
 const config = {
   // files to load into karma
-  files: ['test/**/*.ts', 'src/**/*.ts'],
+  files: ["test/**/*.ts", "src/**/*.ts"],
 
   // frameworks to use
   // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-  frameworks: ['mocha'],
+  frameworks: ["mocha"],
 
   // Doing 65 seconds to allow for the 20 second firestore tests
   browserNoActivityTimeout: 65000,
@@ -16,15 +16,15 @@ const config = {
   // available preprocessors:
   // https://npmjs.org/browse/keyword/karma-preprocessor
   preprocessors: {
-    '**/*.ts': ['webpack', 'sourcemap']
+    "**/*.ts": ["webpack", "sourcemap"],
   },
 
-  mime: { 'text/x-typescript': ['ts', 'tsx'] },
+  mime: { "text/x-typescript": ["ts", "tsx"] },
 
   // test results reporter to use
   // possible values: 'dots', 'progress', 'coverage-istanbul'
   // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-  reporters: ['mocha'],
+  reporters: ["mocha"],
 
   // web server port
   port: 8089,
@@ -44,7 +44,7 @@ const config = {
   // start these browsers
   // available browser launchers:
   // https://npmjs.org/browse/keyword/karma-launcher
-  browsers: ['ChromeHeadless'],
+  browsers: ["ChromeHeadless"],
 
   webpack: webpackTestConfig,
 
@@ -54,15 +54,15 @@ const config = {
 
   client: {
     mocha: {
-      timeout: 5000
-    }
+      timeout: 5000,
+    },
   },
 
   mochaReporter: {
-    showDiff: true
-  }
+    showDiff: true,
+  },
 };
 
-module.exports = function(karmaConfig){
+module.exports = function (karmaConfig) {
   karmaConfig.set(config);
 };

--- a/firestore-stripe-web-sdk/package.json
+++ b/firestore-stripe-web-sdk/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "postbuild": "node ./postbuild.js",
     "test": "firebase emulators:exec --only firestore,auth --project fake-project-id 'npm run test:unit'",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha test/**/*.spec.ts"
+    "test:unit": "karma start --single-run"
   },
   "keywords": [
     "firebase",
@@ -43,13 +43,20 @@
     "chai-as-promised": "^7.1.1",
     "chai-like": "^1.1.1",
     "firebase-tools": "^9.18.0",
-    "jsdom": "^17.0.0",
-    "jsdom-global": "^3.0.2",
     "mocha": "^9.1.1",
+    "karma": "^6.3.4",
+    "karma-mocha": "^2.0.1",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-webpack": "^4.0.2",
+    "karma-sourcemap-loader": "^0.3.8",
+    "karma-chrome-launcher": "^3.1.0",
+    "webpack": "^4.46.0",
+    "source-map-loader": "^1.1.3",
     "replace-in-file": "^6.2.0",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.2.1",
+    "ts-loader": "^8.3.0",
     "typescript": "^4.4.2"
   },
   "dependencies": {

--- a/firestore-stripe-web-sdk/test/emulator.spec.ts
+++ b/firestore-stripe-web-sdk/test/emulator.spec.ts
@@ -79,6 +79,7 @@ import {
 } from "@firebase/auth";
 
 use(require("chai-like"));
+use(require("chai-as-promised"));
 
 describe("Emulator tests", () => {
   const app: FirebaseApp = initializeApp({

--- a/firestore-stripe-web-sdk/webpack.test.js
+++ b/firestore-stripe-web-sdk/webpack.test.js
@@ -1,0 +1,30 @@
+module.exports = {
+  mode: 'development',
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'ts-loader',
+          options: {
+            compilerOptions: {
+              module: 'commonjs',
+              target: 'es2017'
+            }
+          }
+        }
+      },
+      {
+        test: /\.[tj]sx?$/,
+        use: 'source-map-loader',
+        enforce: 'pre'
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.ts']
+  },
+  plugins: []
+};

--- a/firestore-stripe-web-sdk/webpack.test.js
+++ b/firestore-stripe-web-sdk/webpack.test.js
@@ -1,30 +1,30 @@
 module.exports = {
-  mode: 'development',
-  devtool: 'source-map',
+  mode: "development",
+  devtool: "source-map",
   module: {
     rules: [
       {
         test: /\.tsx?$/,
         exclude: /node_modules/,
         use: {
-          loader: 'ts-loader',
+          loader: "ts-loader",
           options: {
             compilerOptions: {
-              module: 'commonjs',
-              target: 'es2017'
-            }
-          }
-        }
+              module: "commonjs",
+              target: "es2017",
+            },
+          },
+        },
       },
       {
         test: /\.[tj]sx?$/,
-        use: 'source-map-loader',
-        enforce: 'pre'
-      }
-    ]
+        use: "source-map-loader",
+        enforce: "pre",
+      },
+    ],
   },
   resolve: {
-    extensions: ['.js', '.ts']
+    extensions: [".js", ".ts"],
   },
-  plugins: []
+  plugins: [],
 };


### PR DESCRIPTION
We currently run tests using mocha (nodejs) + jsdom to emulate a browser environment. It loads the Nodejs version of the Firestore SDK which throws `TypeError: Invalid URL: index.node.cjs.js` because jsdom confuses it to think it's executing in a browser.

The PR changes the tests to run in a real browser (chrome) to workaround this issue, and it's a more reliable test setup because tests will execute in the same environment where the SDK will be used.
