### PR TITLE
chore: Changed API ref link to an absolute URL

### DIFF
--- a/firestore-stripe-web-sdk/README.md
+++ b/firestore-stripe-web-sdk/README.md
@@ -9,7 +9,7 @@ payments.
 
 # API Reference
 
-[API reference](./markdown/index.md)
+[API reference](https://github.com/stripe/stripe-firebase-extensions/blob/next/firestore-stripe-web-sdk/markdown/index.md)
 
 # Example usage
 


### PR DESCRIPTION
Changing to a absolute URL, so it will work correctly when rendered outside github too (e.g. https://www.npmjs.com/package/@stripe/firestore-stripe-payments)