### PR TITLE
fix: Registering correct package name

### DIFF
--- a/firestore-stripe-web-sdk/src/init.ts
+++ b/firestore-stripe-web-sdk/src/init.ts
@@ -16,7 +16,7 @@
 
 import { FirebaseApp, registerVersion } from "@firebase/app";
 
-registerVersion("@stripe/firestore-stripe-payments", "__VERSION__");
+registerVersion("firestore-stripe-payments", "__VERSION__");
 
 /**
  * Serves as the main entry point to this library. Initializes the client SDK,


### PR DESCRIPTION
It turns out Firebase JS SDK doesn't support registering scoped package names:

```
@firebase/app:', 'Unable to register library "@stripe/firestore-stripe-payments" with version "__VERSION__": library name "@stripe/firestore-stripe-payments" contains illegal characters (whitespace or "/")'
```

I'm shortening the package name to the unscoped part.