### PR TITLE
feat: Added getCurrentUserPayments API

### DIFF
--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments.api.md
@@ -44,11 +44,19 @@ export interface CreateCheckoutSessionOptions {
 // @public
 export function getCurrentUserPayment(payments: StripePayments, paymentId: string): Promise<Payment>;
 
+// @public (undocumented)
+export function getCurrentUserPayments(payments: StripePayments, options?: GetPaymentsOptions): Promise<Payment[]>;
+
 // @public
 export function getCurrentUserSubscription(payments: StripePayments, subscriptionId: string): Promise<Subscription>;
 
 // @public
 export function getCurrentUserSubscriptions(payments: StripePayments, options?: GetSubscriptionsOptions): Promise<Subscription[]>;
+
+// @public
+export interface GetPaymentsOptions {
+    status?: PaymentStatus | PaymentStatus[];
+}
 
 // @public
 export function getPrice(payments: StripePayments, productId: string, priceId: string): Promise<Price>;
@@ -126,7 +134,7 @@ export interface Payment {
         product: string;
         price: string;
     }>;
-    readonly status: PaymentState;
+    readonly status: PaymentStatus;
     readonly uid: string;
 }
 
@@ -134,7 +142,7 @@ export interface Payment {
 export type PaymentMethodType = "card" | "acss_debit" | "afterpay_clearpay" | "alipay" | "bacs_debit" | "bancontact" | "boleto" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "oxxo" | "p24" | "sepa_debit" | "sofort" | "wechat_pay";
 
 // @public
-export type PaymentState = "requires_payment_method" | "requires_confirmation" | "requires_action" | "processing" | "requires_capture" | "cancelled" | "succeeded";
+export type PaymentStatus = "requires_payment_method" | "requires_confirmation" | "requires_action" | "processing" | "requires_capture" | "cancelled" | "succeeded";
 
 // @public
 export interface Price {

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -38,7 +38,13 @@ export {
   SessionCreateParams,
 } from "./session";
 
-export { Payment, PaymentState, getCurrentUserPayment } from "./payment";
+export {
+  GetPaymentsOptions,
+  Payment,
+  PaymentStatus,
+  getCurrentUserPayment,
+  getCurrentUserPayments,
+} from "./payment";
 
 export {
   GetProductOptions,

--- a/firestore-stripe-web-sdk/test/payment.spec.ts
+++ b/firestore-stripe-web-sdk/test/payment.spec.ts
@@ -19,12 +19,13 @@ import { fake as sinonFake, SinonSpy } from "sinon";
 import { FirebaseApp } from "@firebase/app";
 import {
   getCurrentUserPayment,
+  getCurrentUserPayments,
   getStripePayments,
   Payment,
   StripePayments,
   StripePaymentsError,
 } from "../src/index";
-import { payment1 } from "./testdata";
+import { payment1, payment2 } from "./testdata";
 import { setUserDAO, UserDAO } from "../src/user";
 import { PaymentDAO, setPaymentDAO } from "../src/payment";
 
@@ -96,6 +97,106 @@ describe("getCurrentUserPayment()", () => {
     await expect(getCurrentUserPayment(payments, "pay1")).to.be.rejectedWith(
       error
     );
+
+    expect(userFake).to.have.been.calledOnce;
+  });
+});
+
+describe("getCurrentUserPayments()", () => {
+  it("should return all payments when called without options", async () => {
+    const fake: SinonSpy = sinonFake.resolves([payment1, payment2]);
+    setPaymentDAO(payments, testPaymentDAO("getPayments", fake));
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+
+    const paymentData: Payment[] = await getCurrentUserPayments(payments);
+
+    expect(paymentData).to.eql([payment1, payment2]);
+    expect(fake).to.have.been.calledOnceWithExactly("alice", {});
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  it("should return empty array if no payments are available", async () => {
+    const fake: SinonSpy = sinonFake.resolves([]);
+    setPaymentDAO(payments, testPaymentDAO("getPayments", fake));
+
+    const paymentData: Payment[] = await getCurrentUserPayments(payments);
+
+    expect(paymentData).to.be.an("array").and.be.empty;
+    expect(fake).to.have.been.calledOnceWithExactly("alice", {});
+  });
+
+  it("should only return payments with the given status", async () => {
+    const fake: SinonSpy = sinonFake.resolves([payment1]);
+    setPaymentDAO(payments, testPaymentDAO("getPayments", fake));
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+
+    const paymentData: Payment[] = await getCurrentUserPayments(payments, {
+      status: "succeeded",
+    });
+
+    expect(paymentData).to.eql([payment1]);
+    expect(fake).to.have.been.calledOnceWithExactly("alice", {
+      status: ["succeeded"],
+    });
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  it("should only return payments with the given statuses", async () => {
+    const fake: SinonSpy = sinonFake.resolves([payment1, payment2]);
+    setPaymentDAO(payments, testPaymentDAO("getPayments", fake));
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+
+    const paymentData: Payment[] = await getCurrentUserPayments(payments, {
+      status: ["succeeded", "requires_action"],
+    });
+
+    expect(paymentData).to.eql([payment1, payment2]);
+    expect(fake).to.have.been.calledOnceWithExactly("alice", {
+      status: ["succeeded", "requires_action"],
+    });
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  [null, [], {}, true, 1, 0, NaN].forEach((status: any) => {
+    it(`should throw when called with invalid status option: ${JSON.stringify(
+      status
+    )}`, async () => {
+      expect(() =>
+        getCurrentUserPayments(payments, {
+          status,
+        })
+      ).to.throw("status must be a non-empty array.");
+    });
+  });
+
+  it("should reject when the payment data access object throws", async () => {
+    const error: StripePaymentsError = new StripePaymentsError(
+      "not-found",
+      "no such payment"
+    );
+    const fake: SinonSpy = sinonFake.rejects(error);
+    setPaymentDAO(payments, testPaymentDAO("getPayments", fake));
+    const userFake: SinonSpy = sinonFake.returns("alice");
+    setUserDAO(payments, testUserDAO(userFake));
+
+    await expect(getCurrentUserPayments(payments)).to.be.rejectedWith(error);
+
+    expect(fake).to.have.been.calledOnceWithExactly("alice", {});
+    expect(userFake).to.have.been.calledOnce.and.calledBefore(fake);
+  });
+
+  it("should reject when the user data access object throws", async () => {
+    const error: StripePaymentsError = new StripePaymentsError(
+      "unauthenticated",
+      "user not signed in"
+    );
+    const userFake: SinonSpy = sinonFake.throws(error);
+    setUserDAO(payments, testUserDAO(userFake));
+
+    await expect(getCurrentUserPayments(payments)).to.be.rejectedWith(error);
 
     expect(userFake).to.have.been.calledOnce;
   });

--- a/firestore-stripe-web-sdk/test/testdata.ts
+++ b/firestore-stripe-web-sdk/test/testdata.ts
@@ -332,7 +332,6 @@ export const rawPaymentData: PaymentData = {
     currency: "USD",
     customer: null,
     description: null,
-    id: "pay1",
     invoice: null,
     metadata: {},
     payment_method_types: ["card"],
@@ -353,7 +352,6 @@ export const rawPaymentData: PaymentData = {
     currency: "USD",
     customer: "alice",
     description: "Test description",
-    id: "pay2",
     invoice: "invoice2",
     metadata: {},
     payment_method_types: ["card"],
@@ -364,7 +362,27 @@ export const rawPaymentData: PaymentData = {
       },
     ],
     product: "premium",
-    status: "succeeded",
+    status: "requires_action",
+  },
+  pay3: {
+    amount: 999,
+    amount_capturable: 0,
+    amount_received: 0,
+    created: 1632951980,
+    currency: "USD",
+    customer: "alice",
+    description: "Test description",
+    invoice: "invoice3",
+    metadata: {},
+    payment_method_types: ["card"],
+    prices: [
+      {
+        product: "premium",
+        price: "price1",
+      },
+    ],
+    product: "premium",
+    status: "processing",
   },
 };
 
@@ -408,6 +426,28 @@ export const payment2: Payment = {
       price: "price1",
     },
   ],
-  status: "succeeded",
+  status: "requires_action",
+  uid: "dynamic",
+};
+
+export const payment3: Payment = {
+  amount: 999,
+  amount_capturable: 0,
+  amount_received: 0,
+  created: "Wed, 29 Sep 2021 21:46:20 GMT",
+  currency: "USD",
+  customer: "alice",
+  description: "Test description",
+  id: "pay3",
+  invoice: "invoice3",
+  metadata: {},
+  payment_method_types: ["card"],
+  prices: [
+    {
+      product: "premium",
+      price: "price1",
+    },
+  ],
+  status: "processing",
   uid: "dynamic",
 };


### PR DESCRIPTION
* Added `getCurrentUserPayments()` function to fetch multiple one-time payments from Firestore.
* Renamed `PaymentState` to `PaymentStatus` for consistency with `SubscriptionStatus`.