### PR TITLE
feat(firestore-stripe-web-sdk): Added onCurrentUserPaymentUpdate() API

### DIFF
--- a/firestore-stripe-web-sdk/etc/firestore-stripe-payments.api.md
+++ b/firestore-stripe-web-sdk/etc/firestore-stripe-payments.api.md
@@ -111,6 +111,9 @@ export interface LineItemSessionCreateParams extends CommonSessionCreateParams {
 }
 
 // @public
+export function onCurrentUserPaymentUpdate(payments: StripePayments, onUpdate: (snapshot: PaymentSnapshot) => void, onError?: (error: StripePaymentsError) => void): () => void;
+
+// @public
 export function onCurrentUserSubscriptionUpdate(payments: StripePayments, onUpdate: (snapshot: SubscriptionSnapshot) => void, onError?: (error: StripePaymentsError) => void): () => void;
 
 // @public
@@ -139,7 +142,21 @@ export interface Payment {
 }
 
 // @public
+export type PaymentChangeType = "added" | "modified" | "removed";
+
+// @public
 export type PaymentMethodType = "card" | "acss_debit" | "afterpay_clearpay" | "alipay" | "bacs_debit" | "bancontact" | "boleto" | "eps" | "fpx" | "giropay" | "grabpay" | "ideal" | "klarna" | "oxxo" | "p24" | "sepa_debit" | "sofort" | "wechat_pay";
+
+// @public
+export interface PaymentSnapshot {
+    changes: Array<{
+        type: PaymentChangeType;
+        payment: Payment;
+    }>;
+    empty: boolean;
+    payments: Payment[];
+    size: number;
+}
 
 // @public
 export type PaymentStatus = "requires_payment_method" | "requires_confirmation" | "requires_action" | "processing" | "requires_capture" | "cancelled" | "succeeded";

--- a/firestore-stripe-web-sdk/src/index.ts
+++ b/firestore-stripe-web-sdk/src/index.ts
@@ -41,9 +41,12 @@ export {
 export {
   GetPaymentsOptions,
   Payment,
+  PaymentChangeType,
+  PaymentSnapshot,
   PaymentStatus,
   getCurrentUserPayment,
   getCurrentUserPayments,
+  onCurrentUserPaymentUpdate,
 } from "./payment";
 
 export {


### PR DESCRIPTION
- Add `onCurrentUserPaymentUpdate()` API
- Add unit tests and emulator tests

Note: this change is tracking the `payments-api` feature branch.