### PR TITLE
fix(firestore-stripe-invoices): updated external services 

### DIFF
--- a/firestore-stripe-invoices/extension.yaml
+++ b/firestore-stripe-invoices/extension.yaml
@@ -40,7 +40,7 @@ billingRequired: true # this extension makes requests to a third party API (Stri
 
 externalServices:
   - name: Stripe
-  - pricingUri: https://stripe.com/pricing
+    pricingUri: https://stripe.com/pricing
 
 roles:
   - role: firebaseauth.viewer


### PR DESCRIPTION
An installation error occurs on the `firestore-stripe-invoices` extension. 

```
 generic::invalid_argument: extension.yaml is invalid: generic::invalid_argument: Request had 2 validation errors: `spec.externalServices.0`: ExternalService must specify `pricingUri`; `spec.externalServices.1`: ExternalService must specify `name`.
```

This PR updates the `pricingUri` to the correct value in the extensions yaml configuration.