### PR TITLE
chore(firestore-stripe-invoices): added validation for payment due days.

### DIFF
--- a/firestore-stripe-invoices/extension.yaml
+++ b/firestore-stripe-invoices/extension.yaml
@@ -159,6 +159,9 @@ params:
       What is the default number of days the customer has before their payment is due?
       The invoice automatically closes after this number of days.
       You can override this default value for each invoice.
+    validationRegex: "^[0-9]+$"
+    validationErrorMessage: >
+      Please enter a valid number
     default: 7
     required: true
 


### PR DESCRIPTION
When installing the `firestore-stripe-invoices` a non numeric value could be added as a value.

This PR adds validation to ensure only numerical values can be added during the installation process.