### PR TITLE
feat(firestore-stripe-payments): added stripe extension events

### DIFF
--- a/firestore-stripe-payments/PREINSTALL.md
+++ b/firestore-stripe-payments/PREINSTALL.md
@@ -35,6 +35,10 @@ applications would want to implement using the extension.
 Use a package manager like NPM to install the above package, and use it in conjunction with
 the Firebase Web SDK.
 
+### Events
+
+This extension emits events, which allows you to listen to and run custom logic at different trigger points during the functioning of the extension. For example you can listen to events when a product has been added via the `product.created` event, or whenever a payment has succeeded through the `invoice.payment_succeeded` event.
+
 #### Additional setup
 
 Before installing this extension, set up the following Firebase services in your Firebase project:

--- a/firestore-stripe-payments/PREINSTALL.md
+++ b/firestore-stripe-payments/PREINSTALL.md
@@ -60,10 +60,11 @@ This extension uses the following Firebase services which may have associated ch
 - Cloud Functions
 - Cloud Secret Manager
 - Firebase Authentication
+- If you enable events [Eventarc fees apply](https://cloud.google.com/eventarc/pricing).
 
 This extension also uses the following third-party services:
 
-- Stripe Payments ([pricing information](https://stripe.com/pricing)) 
+- Stripe Payments ([pricing information](https://stripe.com/pricing))
 - Stripe Billing (when using subscriptions. [pricing information](https://stripe.com/pricing#billing-pricing))
 
 You are responsible for any costs associated with your use of these services.

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -55,7 +55,7 @@ resources:
       Creates a Stripe customer object when a new user signs up.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       eventTrigger:
         eventType: providers/firebase.auth/eventTypes/user.create
         resource: projects/${PROJECT_ID}
@@ -66,7 +66,7 @@ resources:
       Creates a Checkout session to collect the customer's payment details.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.create
         resource: projects/${PROJECT_ID}/databases/(default)/documents/${CUSTOMERS_COLLECTION}/{uid}/checkout_sessions/{id}
@@ -77,7 +77,7 @@ resources:
       Creates links to the customer portal for the user to manage their payment & subscription details.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       httpsTrigger: {}
 
   - name: handleWebhookEvents
@@ -86,7 +86,7 @@ resources:
       Handles Stripe webhook events to keep subscription statuses in sync and update custom claims.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       httpsTrigger: {}
 
   - name: onUserDeleted
@@ -95,7 +95,7 @@ resources:
       Deletes the Stripe customer object and cancels all their subscriptions when the user is deleted in Firebase Authentication.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       eventTrigger:
         eventType: providers/firebase.auth/eventTypes/user.delete
         resource: projects/${PROJECT_ID}
@@ -106,7 +106,7 @@ resources:
       Deletes the Stripe customer object and cancels all their subscriptions when the customer doc in Cloud Firestore is deleted.
     properties:
       location: ${LOCATION}
-      runtime: nodejs10
+      runtime: nodejs14
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.delete
         resource: projects/${PROJECT_ID}/databases/(default)/documents/${CUSTOMERS_COLLECTION}/{uid}

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -246,3 +246,75 @@ params:
       and configuring this value.
     example: whsec_1234567890
     required: false
+events:
+  - type: com.stripe.v1.product.created
+    description: Occurs whenever a product is created.
+
+  - type: com.stripe.v1.product.updated
+    description: Occurs whenever a product is updated.
+
+  - type: com.stripe.v1.product.deleted
+    description: Occurs whenever a product is deleted.
+
+  - type: com.stripe.v1.price.created
+    description: Occurs whenever a price is created.
+
+  - type: com.stripe.v1.price.updated
+    description: Occurs whenever a price is updated.
+
+  - type: com.stripe.v1.price.deleted
+    description: Occurs whenever a price is deleted.
+
+  - type: com.stripe.v1.checkout.session.completed
+    description: Occurs when a Checkout Session has been successfully completed.
+
+  - type: com.stripe.v1.checkout.session.async_payment_succeeded
+    description: Occurs when a payment intent using a delayed payment method finally succeeds.
+
+  - type: com.stripe.v1.checkout.session.async_payment_failed
+    description: Occurs when a payment intent using a delayed payment method fails.
+
+  - type: com.stripe.v1.customer.subscription.created
+    description: Occurs whenever a customer is signed up for a new plan.
+
+  - type: com.stripe.v1.customer.subscription.updated
+    description: Occurs whenever a subscription changes (e.g., switching from one plan to another, or changing the status from trial to active).
+
+  - type: com.stripe.v1.customer.subscription.deleted
+    description: Occurs whenever a customer's subscription ends.
+
+  - type: com.stripe.v1.tax_rate.created
+    description: Occurs whenever a new tax rate is created.
+
+  - type: com.stripe.v1.tax_rate.updated
+    description: Occurs whenever a tax rate is updated.
+
+  - type: com.stripe.v1.invoice.paid
+    description: Occurs whenever an invoice payment attempt succeeds or an invoice is marked as paid out-of-band.
+
+  - type: com.stripe.v1.invoice.payment_succeeded
+    description: Occurs whenever an invoice payment attempt succeeds.
+
+  - type: com.stripe.v1.invoice.payment_failed
+    description: Occurs whenever an invoice payment attempt fails, due either to a declined payment or to the lack of a stored payment method.
+
+  - type: com.stripe.v1.invoice.upcoming
+    description: Occurs X number of days before a subscription is scheduled to create an invoice that is automatically charged—where X is determined by your subscriptions settings.
+
+  - type: com.stripe.v1.invoice.marked_uncollectible
+    description: Occurs whenever an invoice is marked uncollectible.
+
+  - type: com.stripe.v1.invoice.payment_action_required
+    description: Occurs whenever an invoice payment attempt requires further user action to complete.
+
+  - type: com.stripe.v1.payment_intent.processing
+    description: Occurs when a PaymentIntent has started processing.
+
+  - type: com.stripe.v1.payment_intent.succeeded
+    description: Occurs when a PaymentIntent has successfully completed payment.
+
+  - type: com.stripe.v1.payment_intent.canceled
+    description: Occurs when a PaymentIntent is canceled.
+
+  - type: com.stripe.v1.payment_intent.payment_failed
+    description: Occurs when a PaymentIntent has failed the attempt to create a payment method or a payment.

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -249,72 +249,49 @@ params:
 events:
   - type: com.stripe.v1.product.created
     description: Occurs whenever a product is created.
-
   - type: com.stripe.v1.product.updated
     description: Occurs whenever a product is updated.
-
   - type: com.stripe.v1.product.deleted
     description: Occurs whenever a product is deleted.
-
   - type: com.stripe.v1.price.created
     description: Occurs whenever a price is created.
-
   - type: com.stripe.v1.price.updated
     description: Occurs whenever a price is updated.
-
   - type: com.stripe.v1.price.deleted
     description: Occurs whenever a price is deleted.
-
   - type: com.stripe.v1.checkout.session.completed
     description: Occurs when a Checkout Session has been successfully completed.
-
   - type: com.stripe.v1.checkout.session.async_payment_succeeded
     description: Occurs when a payment intent using a delayed payment method finally succeeds.
-
   - type: com.stripe.v1.checkout.session.async_payment_failed
     description: Occurs when a payment intent using a delayed payment method fails.
-
   - type: com.stripe.v1.customer.subscription.created
     description: Occurs whenever a customer is signed up for a new plan.
-
   - type: com.stripe.v1.customer.subscription.updated
     description: Occurs whenever a subscription changes (e.g., switching from one plan to another, or changing the status from trial to active).
-
   - type: com.stripe.v1.customer.subscription.deleted
     description: Occurs whenever a customer's subscription ends.
-
   - type: com.stripe.v1.tax_rate.created
     description: Occurs whenever a new tax rate is created.
-
   - type: com.stripe.v1.tax_rate.updated
     description: Occurs whenever a tax rate is updated.
-
   - type: com.stripe.v1.invoice.paid
     description: Occurs whenever an invoice payment attempt succeeds or an invoice is marked as paid out-of-band.
-
   - type: com.stripe.v1.invoice.payment_succeeded
     description: Occurs whenever an invoice payment attempt succeeds.
-
   - type: com.stripe.v1.invoice.payment_failed
     description: Occurs whenever an invoice payment attempt fails, due either to a declined payment or to the lack of a stored payment method.
-
   - type: com.stripe.v1.invoice.upcoming
     description: Occurs X number of days before a subscription is scheduled to create an invoice that is automatically charged—where X is determined by your subscriptions settings.
-
   - type: com.stripe.v1.invoice.marked_uncollectible
     description: Occurs whenever an invoice is marked uncollectible.
-
   - type: com.stripe.v1.invoice.payment_action_required
     description: Occurs whenever an invoice payment attempt requires further user action to complete.
-
   - type: com.stripe.v1.payment_intent.processing
     description: Occurs when a PaymentIntent has started processing.
-
   - type: com.stripe.v1.payment_intent.succeeded
     description: Occurs when a PaymentIntent has successfully completed payment.
-
   - type: com.stripe.v1.payment_intent.canceled
     description: Occurs when a PaymentIntent is canceled.
-
   - type: com.stripe.v1.payment_intent.payment_failed
     description: Occurs when a PaymentIntent has failed the attempt to create a payment method or a payment.

--- a/firestore-stripe-payments/functions/jest.config.js
+++ b/firestore-stripe-payments/functions/jest.config.js
@@ -20,4 +20,8 @@ module.exports = {
     '!**/test-data/**',
   ],
   setupFiles: ['<rootDir>/__tests__/jest.setup.ts'],
+  moduleNameMapper: {
+    'firebase-admin/eventarc':
+      '<rootDir>/node_modules/firebase-admin/lib/eventarc/index.js',
+  },
 };

--- a/firestore-stripe-payments/functions/package.json
+++ b/firestore-stripe-payments/functions/package.json
@@ -18,8 +18,8 @@
   "author": "Stripe (https://stripe.com/)",
   "license": "Apache-2.0",
   "dependencies": {
-    "firebase-admin": "^9.9.0",
-    "firebase-functions": "^3.19.0",
+    "firebase-admin": "^10.2.0",
+    "firebase-functions": "^3.20.1",
     "stripe": "8.191.0"
   },
   "devDependencies": {

--- a/firestore-stripe-payments/functions/package.json
+++ b/firestore-stripe-payments/functions/package.json
@@ -1,5 +1,8 @@
 {
   "name": "firestore-stripe-payments",
+  "engines": {
+    "node": "14"
+  },
   "main": "lib/index.js",
   "scripts": {
     "prepare": "npm run build",
@@ -20,23 +23,24 @@
   "dependencies": {
     "firebase-admin": "^10.2.0",
     "firebase-functions": "^3.20.1",
-    "stripe": "8.191.0"
+    "rimraf": "^3.0.2",
+    "stripe": "8.191.0",
+    "typescript": "^3.9.9",
+    "@types/jest": "^24.9.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^6.0.0",
     "@types/chai": "^4.1.6",
-    "@types/express": "^4.17.11",
-    "@types/jest": "^24.9.1",
+    "@types/express": "^4.17.13",
     "concurrently": "^7.0.0",
     "dotenv": "^16.0.0",
     "envfile": "^6.17.0",
     "firebase-functions-test": "^0.3.3",
-    "jest": "^24.9.0",
     "mocked-env": "^1.3.5",
     "ngrok": "^4.3.1",
     "ts-jest": "^24.1.0",
     "ts-node": "^10.7.0",
-    "typescript": "^3.9.9"
+    "jest": "^24.9.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 import * as admin from 'firebase-admin';
+import { getEventarc } from 'firebase-admin/lib/eventarc';
 import * as functions from 'firebase-functions';
 import Stripe from 'stripe';
 import {
@@ -39,6 +40,12 @@ const stripe = new Stripe(config.stripeSecretKey, {
 });
 
 admin.initializeApp();
+
+const eventChannel =
+  process.env.EVENTARC_CHANNEL &&
+  getEventarc().channel(process.env.EVENTARC_CHANNEL, {
+    allowedEventTypes: process.env.EXT_SELECTED_EVENTS,
+  });
 
 /**
  * Create a customer object in Stripe when a user is created.
@@ -777,6 +784,12 @@ export const handleWebhookEvents = functions.handler.https.onRequest(
               event.type
             );
         }
+
+        eventChannel?.publish({
+          type: `com.stripe.v1.${event.type}`,
+          data: event.data.object,
+        });
+
         logs.webhookHandlerSucceeded(event.id, event.type);
       } catch (error) {
         logs.webhookHandlerError(error, event.id, event.type);

--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import * as admin from 'firebase-admin';
-import { getEventarc } from 'firebase-admin/lib/eventarc';
+import { getEventarc } from 'firebase-admin/eventarc';
 import * as functions from 'firebase-functions';
 import Stripe from 'stripe';
 import {
@@ -785,7 +785,7 @@ export const handleWebhookEvents = functions.handler.https.onRequest(
             );
         }
 
-        eventChannel?.publish({
+        await eventChannel?.publish({
           type: `com.stripe.v1.${event.type}`,
           data: event.data.object,
         });

--- a/firestore-stripe-payments/functions/tsconfig.json
+++ b/firestore-stripe-payments/functions/tsconfig.json
@@ -7,10 +7,9 @@
     "outDir": "lib",
     "sourceMap": true,
     "target": "es2017",
-    "esModuleInterop": true,
-    "moduleResolution": "Node"
+    "esModuleInterop": true
   },
   "compileOnSave": true,
-  "include": ["src", "__tests__"],
-  "exclude": ["__tests__"]
+  "include": ["src"],
+  "exclude": ["node_modules", "__tests__"]
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "devDependencies": {
     "lerna": "^3.4.3",
     "prettier": "^2.4.1"
+  },
+  "dependencies": {
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
`Eventarc` events are now available in the latest firebase-admin sdk.

This PR adds a feature to omit an event based on Stripe event sent through the extensions web-hook. 

- [x] Add events list to the extension yaml.
- [x] Implement `Event Channel` and `Publish` functionality.
- [x] Add documentation to Preinstall