### PR TITLE
fix(firestore-stripe-payments): moved ts dependency to main dependencies

### DIFF
--- a/firestore-stripe-payments/functions/package.json
+++ b/firestore-stripe-payments/functions/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "firebase-admin": "^9.9.0",
     "firebase-functions": "^3.19.0",
-    "stripe": "8.191.0"
+    "stripe": "8.191.0",
+
+    "typescript": "^3.9.9"
   },
   "devDependencies": {
     "@faker-js/faker": "^6.0.0",
@@ -35,8 +37,7 @@
     "mocked-env": "^1.3.5",
     "ngrok": "^4.3.1",
     "ts-jest": "^24.1.0",
-    "ts-node": "^10.7.0",
-    "typescript": "^3.9.9"
+    "ts-node": "^10.7.0"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
When using a `prepare` script for installing/updating an extension in production, all required packages must be included in the main dependencies. 

In this example, an error similar to `cannot find tsc` would likely appear.