### PR TITLE
docs(firestore-stripe-payments): Update APIs for restricted key

### DIFF
--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -48,7 +48,7 @@ Before installing this extension, set up the following Firebase services in your
 
 Then, in the [Stripe Dashboard](https://dashboard.stripe.com):
 
-- Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Plans" resources.
+- Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Prices" resources.
 
 #### Billing
 


### PR DESCRIPTION
Prices API replaces the Plans API, per https://stripe.com/docs/api/plans

> You can now model subscriptions more flexibly using the [Prices API](https://stripe.com/docs/api/coupons#prices). It replaces the Plans API and is backwards compatible to simplify your migration.

In the Stripe dashboard when making a restricted key, there is no option for "Plans". It seems to me that the "Prices" resource should be used instead.