### PR TITLE
chore(firestore-stripe-payments): updated scripts for CI and local testing

### DIFF
--- a/firestore-stripe-payments/functions/__tests__/run-script-watch.ts
+++ b/firestore-stripe-payments/functions/__tests__/run-script-watch.ts
@@ -3,11 +3,6 @@ const concurrently = require('concurrently');
 import { setupProxy, cleanupProxy } from './helpers/setupProxy';
 
 (async () => {
-  /** Clear all webhooks with ngrok.io,
-   * useful for clearing any failed ci testing
-   */
-  // await cleanupAllWebhooks();
-
   const proxyId = await setupProxy();
 
   const { result } = await concurrently(

--- a/firestore-stripe-payments/functions/__tests__/run-script-watch.ts
+++ b/firestore-stripe-payments/functions/__tests__/run-script-watch.ts
@@ -3,34 +3,26 @@ const concurrently = require('concurrently');
 import { setupProxy, cleanupProxy } from './helpers/setupProxy';
 
 (async () => {
+  /** Clear all webhooks with ngrok.io,
+   * useful for clearing any failed ci testing
+   */
+  // await cleanupAllWebhooks();
+
   const proxyId = await setupProxy();
 
-  /* clean stripe webhook on exit */
-  process.on('SIGINT', () => {
-    cleanupProxy(proxyId).then(() => {
-      console.log('Removed webhook ', proxyId);
-      process.exit(0);
-    });
-  });
-
-  await concurrently([
-    {
-      command: 'npx kill-port 5001, npx kill-port 8080',
-      name: 'Ready ports',
-    },
-  ]);
-
-  await concurrently(
+  const { result } = await concurrently(
     [
       {
-        command: 'npm run start:emulator',
-        name: 'emulator',
-      },
-      {
-        command: 'sh ../runTestsWatch.sh',
+        command: 'npm run exec:emulator:watch',
         name: 'testing',
       },
     ],
     {}
   );
+
+  await result.then(async () => {
+    await cleanupProxy(proxyId);
+    console.log('Removed webhook ', proxyId);
+    process.exit(0);
+  });
 })();

--- a/firestore-stripe-payments/functions/__tests__/tsconfig.json
+++ b/firestore-stripe-payments/functions/__tests__/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "types": ["../node_modules/stripe/types/2020-08-27", "jest", "node"],
+    "rootDir": "./"
+  },
+  "include": ["../__tests__"],
+  "exclude": ["../node_modules"]
+}

--- a/firestore-stripe-payments/functions/package.json
+++ b/firestore-stripe-payments/functions/package.json
@@ -12,12 +12,11 @@
     "compile": "tsc",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md",
     "test": "ts-node ./__tests__/run-script.ts",
-    "test:local": "ts-node ./__tests__/run-script-watch.ts",
-    "test:watch": "concurrently \"npm run setup:emulator\" \"jest --watch\"",
+    "test:watch": "ts-node ./__tests__/run-script-watch.ts",
     "start:emulator": "cd ../_emulator && firebase emulators:start -P demo-project",
     "exec:emulator": "cd ../_emulator && firebase emulators:exec \"../runTests.sh\" -P demo-project",
-    "setup:webhooks": "ts-node ./__tests__/helpers/setupProxy.ts",
-    "test-coverage": "jest --coverage --detectOpenHandles --forceExit"
+    "exec:emulator:watch": "cd ../_emulator && firebase emulators:exec \"../runTestsWatch.sh\" -P demo-project",
+    "setup:webhooks": "ts-node ./__tests__/helpers/setupProxy.ts"
   },
   "author": "Stripe (https://stripe.com/)",
   "license": "Apache-2.0",

--- a/firestore-stripe-payments/runTests.sh
+++ b/firestore-stripe-payments/runTests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 cd ../functions
-jest
+jest --coverage

--- a/firestore-stripe-web-sdk/package.json
+++ b/firestore-stripe-web-sdk/package.json
@@ -37,7 +37,7 @@
     "@types/chai-as-promised": "^7.1.4",
     "@types/chai-like": "^1.1.1",
     "@types/mocha": "^9.0.0",
-    "@types/sinon": "^10.0.6",
+    "@types/sinon": "10.0.6",
     "@types/sinon-chai": "^3.2.5",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
- [x] Updated test script. Now includes test coverage.
- [x] Test watch script now successfully waits for emulator to to initialise. Removed test local script.
- [x] Additional `tsconfig` added for testing. Fixes jest warnings.
- [x] Locked `sinon` type to version 10.0.6 to fix future build issues. 