### PR TITLE
feat(firestore-stripe-payments): createPortalLink auth tweaks

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -324,16 +324,15 @@ exports.createCheckoutSession = functions.firestore
 export const createPortalLink = functions.https.onCall(
   async (data, context) => {
     // Checking that the user is authenticated.
-    if (!context.auth) {
+    const uid = context.auth?.uid;
+    if (!uid) {
       // Throwing an HttpsError so that the client gets the error details.
       throw new functions.https.HttpsError(
-        'failed-precondition',
+        'unauthenticated',
         'The function must be called while authenticated!'
       );
     }
-    const uid = context.auth.uid;
     try {
-      if (!uid) throw new Error('Not authenticated!');
       const { returnUrl: return_url, locale = 'auto', configuration } = data;
       // Get stripe customer id
       const customer = (


### PR DESCRIPTION
This PR does two small things to the `createPortalLink` cloud function.

1. Throws 'unauthenticated' code instead of 'failed-precondition' in response to unauthenticated requests. Not a huge problem but the `unauthenticated` `HttpsError` code is provided by Firebase specifically for this purpose.
2. Uses optional chaining (supported in Node 14) to avoid redundant check for `context.auth.uid`. Also not a big deal but it's nice to avoid the extra conditional that could needlessly throw a generic error.

