### PR TITLE
fixes broken link to js documentation

### DIFF
--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -28,7 +28,7 @@ The design for Stripe Checkout and the customer portal can be customized in your
 #### Recommended usage
 
 If you're building on the web platform, you can use this extension for any of your payment use cases.
-You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/blob/web-sdk/firestore-stripe-web-sdk/README.md)
+You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/tree/next/firestore-stripe-web-sdk#readme)
 JavaScript package to easily access this extension from web clients. This client SDK provides
 TypeScript type definitions and high-level convenience APIs for most common operations client
 applications would want to implement using the extension.


### PR DESCRIPTION
I was trying to find the documentation for `@stripe/firestore-stripe-payments`, but the internal link I found in the repository was broken. I think I found the readme document that was intended to be linked though.