### PR TITLE
fix(firestore-stripe-invoices): Change status to 404 when invoice is not found in firestore on updateInvoice

### DIFF
--- a/firestore-stripe-invoices/functions/src/index.ts
+++ b/firestore-stripe-invoices/functions/src/index.ts
@@ -264,7 +264,7 @@ export const updateInvoice = functions.handler.https.onRequest(
     if (invoicesInFirestore.size !== 1) {
       logs.unexpectedInvoiceAmount(invoicesInFirestore.size, invoice.id);
 
-      resp.status(500).send(`Invoice not found.`);
+      resp.status(404).send(`Invoice not found.`);
       return;
     }
 


### PR DESCRIPTION
I use stripe-invoices with stripe-payment.
Every time I create a subscription(which creates an invoice), the `updateInovice` hook is called by `invoice.created`, and raises a 500 error.

I think the status code should be 404, not 500, or `invoice.created` should not be included in the documentation.
![nitte-dev_-_Send_Invoices_using_Stripe_-_Firebase_コンソール](https://user-images.githubusercontent.com/6919381/194587263-167917e6-66fb-42af-9c99-6dacedb8c7e0.png)
