### PR TITLE
feat: Add us-west1 as deployable function region

### DIFF
--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -127,6 +127,8 @@ params:
         value: us-east1
       - label: Northern Virginia (us-east4)
         value: us-east4
+      - label: Oregon (us-west1)
+        value: us-west1        
       - label: Los Angeles (us-west2)
         value: us-west2
       - label: Salt Lake City (us-west3)


### PR DESCRIPTION
The us-west1 region is missing from the list of regions for applying for the stripe extension.