### PR TITLE
chore: 2022-11-30 release

### DIFF
--- a/firestore-stripe-payments/CHANGELOG.md
+++ b/firestore-stripe-payments/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.3.2 - 2022-11-30
+[chore] Added support for `us-west1` as a deployable region for Firebase functions. [#464]
+
 ## Version 0.3.1 - 2022-08-24
 [chore] Added `package-lock.json` to version control to prevent installation issues. [#426]
 

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-stripe-payments
-version: 0.3.1
+version: 0.3.2
 specVersion: v1beta
 
 displayName: Run Payments with Stripe

--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -35,7 +35,7 @@ const stripe = new Stripe(config.stripeSecretKey, {
   // https://stripe.com/docs/building-plugins#setappinfo
   appInfo: {
     name: 'Firebase firestore-stripe-payments',
-    version: '0.3.1',
+    version: '0.3.2',
   },
 });
 


### PR DESCRIPTION
* `firestore-stripe-payments@0.3.2` (477ceef1272c7d2a48afecdc82bc5146bf7043dc).