### PR TITLE
feat(firestore-stripe-payments): Support `payment_method_collection`

### DIFF
--- a/firestore-stripe-payments/CHANGELOG.md
+++ b/firestore-stripe-payments/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 0.3.2 - 2022-11-30
+[chore] Added support for `us-west1` as a deployable region for Firebase functions. [#464]
+
 ## Version 0.3.1 - 2022-08-24
 [chore] Added `package-lock.json` to version control to prevent installation issues. [#426]
 

--- a/firestore-stripe-payments/PREINSTALL.md
+++ b/firestore-stripe-payments/PREINSTALL.md
@@ -50,7 +50,7 @@ Before installing this extension, set up the following Firebase services in your
 
 Then, in the [Stripe Dashboard](https://dashboard.stripe.com):
 
-- Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Plans" resources.
+- Create a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access for the "Customers", "Checkout Sessions" and "Customer portal" resources, and read-only access for the "Subscriptions" and "Prices" resources.
 
 #### Billing
 

--- a/firestore-stripe-payments/PREINSTALL.md
+++ b/firestore-stripe-payments/PREINSTALL.md
@@ -27,7 +27,7 @@ For all other scenarios you can use the [stripe-android](https://github.com/stri
 
 #### Client SDK
 
-You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/blob/web-sdk/firestore-stripe-web-sdk/README.md)
+You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/blob/next/firestore-stripe-web-sdk/README.md)
 JavaScript package to easily access this extension from web clients. This client SDK provides
 TypeScript type definitions and high-level convenience APIs for most common operations client
 applications would want to implement using the extension.

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -28,7 +28,7 @@ The design for Stripe Checkout and the customer portal can be customized in your
 #### Recommended usage
 
 If you're building on the web platform, you can use this extension for any of your payment use cases.
-You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/blob/web-sdk/firestore-stripe-web-sdk/README.md)
+You can use the [`@stripe/firestore-stripe-payments`](https://github.com/stripe/stripe-firebase-extensions/blob/next/firestore-stripe-web-sdk/README.md)
 JavaScript package to easily access this extension from web clients. This client SDK provides
 TypeScript type definitions and high-level convenience APIs for most common operations client
 applications would want to implement using the extension.

--- a/firestore-stripe-payments/README.md
+++ b/firestore-stripe-payments/README.md
@@ -85,7 +85,7 @@ Starting August 17 2020, you will be billed a small amount (typically less than 
 
 * Automatically delete Stripe customer objects: Do you want to automatically delete customer objects in Stripe?  When a user is deleted in Firebase Authentication or in Cloud Firestore and set to 'Auto delete'  the extension will delete their customer object in Stripe which will immediately cancel all subscriptions for the user.
 
-* Stripe API key with restricted access: What is your Stripe API key?  We recommend creating a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access only for the "Customers", "Checkout Sessions" and "Customer portal" resources. And read-only access for the "Subscriptions" and "Plans" resources.
+* Stripe API key with restricted access: What is your Stripe API key?  We recommend creating a new [restricted key](https://stripe.com/docs/keys#limit-access) with write access only for the "Customers", "Checkout Sessions" and "Customer portal" resources. And read-only access for the "Subscriptions" and "Prices" resources.
 
 * Stripe webhook secret: This is your signing secret for a Stripe-registered webhook.  This webhook can only be registered after installation. Leave this value untouched during installation, then follow the  postinstall instructions for registering your webhook and configuring this value.
 

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-stripe-payments
-version: 0.3.1
+version: 0.3.2
 specVersion: v1beta
 
 displayName: Run Payments with Stripe

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -233,7 +233,7 @@ params:
       What is your Stripe API key?
       We recommend creating a new [restricted key](https://stripe.com/docs/keys#limit-access)
       with write access only for the "Customers", "Checkout Sessions" and "Customer portal" resources.
-      And read-only access for the "Subscriptions" and "Plans" resources.
+      And read-only access for the "Subscriptions" and "Prices" resources.
     example: rk_live_1234567890
     required: true
 

--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -35,7 +35,7 @@ const stripe = new Stripe(config.stripeSecretKey, {
   // https://stripe.com/docs/building-plugins#setappinfo
   appInfo: {
     name: 'Firebase firestore-stripe-payments',
-    version: '0.3.1',
+    version: '0.3.2',
   },
 });
 

--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -144,6 +144,7 @@ exports.createCheckoutSession = functions
       consent_collection = {},
       expires_at,
       phone_number_collection = {},
+      payment_method_collection
     } = snap.data();
     try {
       logs.creatingCheckoutSession(context.params.id);
@@ -196,6 +197,7 @@ exports.createCheckoutSession = functions
           after_expiration,
           consent_collection,
           phone_number_collection,
+          payment_method_collection,
           ...(expires_at && { expires_at }),
         };
         if (payment_method_types) {


### PR DESCRIPTION
Based on documentation https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-payment_method_collection and https://stripe.com/docs/payments/checkout/free-trials, this param will allow for trials that do not require a credit card.

I'm not sure how to build/test so someone may need to verify

Feature Request tracked in #476 - https://github.com/stripe/stripe-firebase-extensions/issues/476