### PR TITLE
fix(firestore-stripe-payments): Address issue where `insertInvoiceRecord` function fails

### DIFF
--- a/firestore-stripe-payments/functions/src/index.ts
+++ b/firestore-stripe-payments/functions/src/index.ts
@@ -620,10 +620,13 @@ const insertInvoiceRecord = async (invoice: Stripe.Invoice) => {
     );
   }
 
+  // An Invoice object does not always have an associated Payment Intent
+  const recordId: string = (invoice.payment_intent as string) ?? invoice.id;
+
   // Update subscription payment with price data
   await customersSnap.docs[0].ref
     .collection('payments')
-    .doc(invoice.payment_intent as string)
+    .doc(recordId)
     .set({ prices }, { merge: true });
   logs.firestoreDocCreated('invoices', invoice.id);
 };


### PR DESCRIPTION
In case where the Invoice has no associated Payment Intent, the Firestore collection write would fail.

This PR fixes this by deferring the the `invoice.id` if no Payment Intent when writing to the Firestore collection.

Fixes #505, #368