### PR TITLE
misc: corrent spelling in Subscription interface comments

### DIFF
--- a/firestore-stripe-payments/functions/src/interfaces.ts
+++ b/firestore-stripe-payments/functions/src/interfaces.ts
@@ -117,7 +117,7 @@ export interface Subscription {
    */
   price: FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>;
   /**
-   * Array of price references. If you prvoide multiple recurring prices to the checkout session via the `line_items` parameter,
+   * Array of price references. If you provide multiple recurring prices to the checkout session via the `line_items` parameter,
    * this array will hold the references for all recurring prices for this subscription. `price === prices[0]`.
    */
   prices: Array<


### PR DESCRIPTION
Just noticed a wrong spelling in the document, so made a tiny pull request to fix the change. 😄 