### PR TITLE
Fix: Avoid creating duplicate Stripe customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # UPDATE 2023-10-08:
-This project has now being officailly transferred to [Invertase](https://github.com/invertase), who will maintain this extension going forward. Please see [this issue](https://github.com/stripe/stripe-firebase-extensions/issues/524) for more details. 
-It is now reccomended to uninstall the `stripe/firestore-stripe-payments` extension and install `invertase/firestore-stripe-payments` from the Firebase Extension Hub.
+This project has now being officially transferred to [Invertase](https://github.com/invertase), who will maintain this extension going forward. Please see [this issue](https://github.com/stripe/stripe-firebase-extensions/issues/524) for more details. 
+It is now recommended to uninstall the `stripe/firestore-stripe-payments` extension and install `invertase/firestore-stripe-payments` from the Firebase Extension Hub.
 
-Alternativley, you can also use the following link to convert your current installation to the Invertase version
+Alternatively, you can also use the following link to convert your current installation to the Invertase version
 
 `https://console.firebase.google.com/project/_/extensions/install?instanceId=STRIPE_EXTENSION_INSTANCE_ID&ref=invertase%2Ffirestore-stripe-payments@0.3.5`
 


### PR DESCRIPTION
For a Stripe company with existing customers, duplicate Stripe customers are created when registering new Firebase Auth credientials.  This fix searches the Stripe customers by email.  If an existing customer is found we update that customer with the firebaseUID metadata.  It also updates the existing customer's phone number if one is supplied. 
