### PR TITLE
feat(firestore-stripe-payments): Update payments collection for refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # UPDATE 2023-10-08:
-This project has now being officailly transferred to [Invertase](https://github.com/invertase), who will maintain this extension going forward. Please see [this issue](https://github.com/stripe/stripe-firebase-extensions/issues/524) for more details. 
-It is now reccomended to uninstall the `stripe/firestore-stripe-payments` extension and install `invertase/firestore-stripe-payments` from the Firebase Extension Hub.
+This project has now being officially transferred to [Invertase](https://github.com/invertase), who will maintain this extension going forward. Please see [this issue](https://github.com/stripe/stripe-firebase-extensions/issues/524) for more details. 
+It is now recommended to uninstall the `stripe/firestore-stripe-payments` extension and install `invertase/firestore-stripe-payments` from the Firebase Extension Hub.
 
-Alternativley, you can also use the following link to convert your current installation to the Invertase version
+Alternatively, you can also use the following link to convert your current installation to the Invertase version
 
 `https://console.firebase.google.com/project/_/extensions/install?instanceId=STRIPE_EXTENSION_INSTANCE_ID&ref=invertase%2Ffirestore-stripe-payments@0.3.5`
 

--- a/firestore-stripe-payments/POSTINSTALL.md
+++ b/firestore-stripe-payments/POSTINSTALL.md
@@ -82,6 +82,7 @@ Here's how to set up the webhook and configure your extension to use it:
    - `payment_intent.succeeded`
    - `payment_intent.canceled`
    - `payment_intent.payment_failed`
+   - `charge.refunded` (optional, will sync refunded payments to Cloud Firestore)
    - `tax_rate.created` (optional)
    - `tax_rate.updated` (optional)
    - `invoice.paid` (optional, will sync invoices to Cloud Firestore)
@@ -192,6 +193,8 @@ db.collection("${param:PRODUCTS_COLLECTION}")
 ### One-time payments on the web
 
 You can create Checkout Sessions for one-time payments when referencing a one-time price ID. One-time payments will be synced to Cloud Firestore into a payments collection for the relevant customer doc if you update your webhook handler in the Stripe dashboard to include the following events: `payment_intent.succeeded`, `payment_intent.payment_failed`, `payment_intent.canceled`, `payment_intent.processing`.
+
+If a payment is refunded in Stripe the associated payment in the payments collection can be updated. To update the payments collection for refunds add the following events to your webhook handler in the Stripe dashboard: `charge.refunded`.
 
 To create a Checkout Session ID for a one-time payment, pass `mode: 'payment` to the Checkout Session doc creation:
 

--- a/firestore-stripe-payments/extension.yaml
+++ b/firestore-stripe-payments/extension.yaml
@@ -349,3 +349,5 @@ events:
     description:
       Occurs when a PaymentIntent has failed the attempt to create a payment
       method or a payment.
+  - type: com.stripe.v1.charge.refunded
+    description: Occurs whenever a charge is refunded.

--- a/firestore-stripe-payments/functions/__tests__/helpers/webhooks.ts
+++ b/firestore-stripe-payments/functions/__tests__/helpers/webhooks.ts
@@ -18,6 +18,7 @@ export const setupWebhooks = async (url) => {
       'payment_intent.succeeded',
       'payment_intent.canceled',
       'payment_intent.payment_failed',
+      'charge.refunded',
       'tax_rate.created',
       'tax_rate.updated',
       'invoice.paid',


### PR DESCRIPTION
Resolves #315

Updates the `charges` property in the payments collection.

Requires adding the `charge.refunded` webhook handler event.

## Screenshots from Firebase Console

Tested by deploying a local copy of the extension in our Firebase test environment.

`charges.data[0]` property of a payment before refund:

![image](https://github.com/user-attachments/assets/cb4c66f0-1dbc-4ca5-92d2-413e2b1d8885)

`charges.data[0]` property of the same payment after refund:

![image](https://github.com/user-attachments/assets/04ce0c14-c8fd-44e3-a2c4-b31feefae921)


Edit: I realised that a retrieving a Payment Intent does not include the `charges` list and it's not listed in the Payment Intent object. The `charges` key does appear in the payments collection, however, so I've updated this change to find and update the Charge object in `charges` when the `charge.refunded` data is received.

Edit 2: I formatted the new code with Prettier and removed the `package-lock.json` changes.