### PR TITLE
docs: correct spelling in Subscription interface

### DIFF
--- a/firestore-stripe-payments/CHANGELOG.md
+++ b/firestore-stripe-payments/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [docs] - update migration link to 3.12
 
+[docs] - fix typo in interface
+
 ## Version 0.3.11 - 2025-05-24
 
 [chore] - improve tests and CI

--- a/firestore-stripe-payments/functions/src/interfaces.ts
+++ b/firestore-stripe-payments/functions/src/interfaces.ts
@@ -117,7 +117,7 @@ export interface Subscription {
    */
   price: FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>;
   /**
-   * Array of price references. If you prvoide multiple recurring prices to the checkout session via the `line_items` parameter,
+   * Array of price references. If you provide multiple recurring prices to the checkout session via the `line_items` parameter,
    * this array will hold the references for all recurring prices for this subscription. `price === prices[0]`.
    */
   prices: Array<


### PR DESCRIPTION
Rebased and non-fork version of https://github.com/invertase/stripe-firebase-extensions/pull/597 so that CI can run.