### PR TITLE
chore: update Stripe API version

### DIFF
--- a/firestore-stripe-payments/functions/src/config.ts
+++ b/firestore-stripe-payments/functions/src/config.ts
@@ -40,7 +40,7 @@ const config: ExtensionConfig = {
     Number(process.env.CREATE_CHECKOUT_SESSION_MIN_INSTANCES) ?? 0,
 };
 
-export const apiVersion = '2022-11-15';
+export const apiVersion = '2023-08-16';
 
 export const stripe = new Stripe(config.stripeSecretKey, {
   apiVersion,


### PR DESCRIPTION
The ability to process no-cost orders (orders with a total of 0) or offer discounts of 100% off coupons at Checkout is introduced in the 2023-08-16 API version or later.
